### PR TITLE
Fix code example for the Field class

### DIFF
--- a/lib/superform/rails.rb
+++ b/lib/superform/rails.rb
@@ -29,8 +29,8 @@ module Superform
       # in your subclass you may have something like this:
       #
       # ```ruby
-      # class MyForm
-      #   class MyLabel < LabelComponent
+      # class MyForm < Superform::Rails::Form
+      #   class MyLabel < Superform::Rails::Components::LabelComponent
       #     def template(&content)
       #       label(form: @field.dom.name, class: "text-bold", &content)
       #     end
@@ -38,7 +38,7 @@ module Superform
       #
       #   class Field < Field
       #     def label(**attributes)
-      #       MyLabel.new(self, attributes: **attributes)
+      #       MyLabel.new(self, **attributes)
       #     end
       #   end
       # end


### PR DESCRIPTION
Fix a syntax error and an issue with namespacing as the Components module is outside the Form class in the code example for the Field class.