### PR TITLE
Fixing a bug in form method generation. Added spec and phlex / nokogi…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,4 @@ gem "rake", "~> 13.0"
 # Run tests
 gem "rspec", "~> 3.0"
 gem "guard-rspec", "~> 4.7"
+gem "phlex-testing-nokogiri", "~> 0.1.0", :group => :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,6 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.5)
     minitest (5.18.1)
     nenv (0.3.0)
     net-imap (0.3.6)
@@ -131,8 +130,9 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
-    nokogiri (1.15.3)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.15.3-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.3-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -145,6 +145,9 @@ GEM
       phlex (~> 1.7)
       rails (>= 6.1, < 8)
       zeitwerk (~> 2.6)
+    phlex-testing-nokogiri (0.1.0)
+      nokogiri (~> 1.13)
+      phlex (>= 0.5)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -214,6 +217,7 @@ PLATFORMS
 
 DEPENDENCIES
   guard-rspec (~> 4.7)
+  phlex-testing-nokogiri (~> 0.1.0)
   rake (~> 13.0)
   rspec (~> 3.0)
   superform!

--- a/lib/superform/rails.rb
+++ b/lib/superform/rails.rb
@@ -125,7 +125,7 @@ module Superform
         end
 
         def _method_field_value
-          @method || @model.persisted? ? "patch" : "post"
+          @method || (@model.persisted? ? "patch" : "post")
         end
 
         def submit_value

--- a/spec/superform_rails_spec.rb
+++ b/spec/superform_rails_spec.rb
@@ -1,0 +1,83 @@
+require 'action_view'
+require 'active_model'
+require 'ostruct'
+require 'phlex'
+require 'phlex-rails'
+require 'phlex/testing/nokogiri'
+require 'phlex/testing/rails/view_helper'
+require 'phlex/testing/view_helper'
+
+class ApplicationComponent < Phlex::HTML
+  include Phlex::Rails::Helpers
+end
+
+class Model
+  include ActiveModel::Model
+end
+
+RSpec.describe Superform::Rails::Form do
+  include Phlex::Testing::ViewHelper
+  include Phlex::Testing::Rails::ViewHelper
+  include Phlex::Testing::Nokogiri::FragmentHelper
+
+  def instance(model:, **kwargs)
+    described_class.new(model, **kwargs ).tap do |instance|
+      allow(instance).to receive(:helpers) do
+        double(
+          'helpers',
+          url_for: 'some_url',
+          form_authenticity_token: 'xxxx'
+        )
+      end
+    end
+  end
+
+  let(:method) { nil }
+  let(:action) { '/submissions' }
+  let(:persisted?) { false }
+  let(:model) do
+    Model.new.tap do |model|
+      allow(model).to receive(:persisted?).and_return(persisted?)
+    end
+  end
+
+  describe 'form' do
+    subject(:form) do
+      render(instance(model:, method:, action:))
+    end
+
+    context 'when @method missing and not persisted' do
+      let(:persisted?) { false }
+      it 'infers form method' do
+        expect(form.css('form').attr('method').value).to be_eql('post')
+      end
+
+      it 'infers method field value' do
+        expect(form.css('input[name=_method]').attr('value').value).to be_eql('post')
+      end
+    end
+
+    context 'when @method missing and persisted' do
+      let(:persisted?) { true }
+      it 'infers form method' do
+        expect(form.css('form').attr('method').value).to be_eql('post')
+      end
+
+      it 'infers method field value' do
+        expect(form.css('input[name=_method]').attr('value').value).to be_eql('patch')
+      end
+    end
+
+    context 'when @method provided' do
+      let(:method) { :post }
+
+      it 'has correct form method' do
+        expect(form.css('form').attr('method').value).to be_eql('post')
+      end
+
+      it 'has correct method field value' do
+        expect(form.css('input[name=_method]').attr('value').value).to be_eql('post')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hey there!

Noticed that Superform::Rails::Form doesn't respect explicit form method passed to the constructor. 

Here's some tests and a fix!

