### PR TITLE
Adds documentation for form and plain old ruby objects

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,83 +2,127 @@
 
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
 
-We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to a positive environment for our community include:
+Examples of behavior that contributes to a positive environment for our
+community include:
 
 * Demonstrating empathy and kindness toward other people
 * Being respectful of differing opinions, viewpoints, and experiences
 * Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the overall community
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
-  advances of any kind
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
 * Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or email
-  address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in
+  a professional setting
 
 ## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
 
-Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at bradgessler@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+bradgessler@gmail.com. All complaints will be reviewed and investigated promptly
+and fairly.
 
-All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
 
 ## Enforcement Guidelines
 
-Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
 
 ### 1. Correction
 
-**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
 
-**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
 
-**Community Impact**: A violation through a single incident or series of actions.
+**Community Impact**: A violation through a single incident or series of
+actions.
 
-**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
 
 ### 3. Temporary Ban
 
-**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
 
-**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
 
 ### 4. Permanent Ban
 
-**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior,  harassment of an individual, or aggression toward or disparagement of classes of individuals.
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
 
-**Consequence**: A permanent ban from any sort of public interaction within the community.
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.0,
-available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code\_of\_conduct.html.
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
 
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -116,7 +116,9 @@ community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code\_of\_conduct.html.
+[https://www.contributor-covenant.org/version/2/0/code\_of\_conduct.html.](
+    https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+)
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).

--- a/README.md
+++ b/README.md
@@ -77,7 +77,10 @@ Then render it in your templates. Here's what it looks like from an Erb file.
 
 ## Customization
 
-Superforms are built out of [Phlex components](https://www.phlex.fun/html/components/). The method names correspeond with the HTML tag, its arguments are attributes, and the blocks are the contents of the tag.
+Superforms are built out of
+[Phlex components](https://www.phlex.fun/html/components/). The method names
+correspeond with the HTML tag, its arguments are attributes, and the blocks are
+the contents of the tag.
 
 ```ruby
 # ./app/views/forms/application_form.rb
@@ -109,7 +112,8 @@ class ApplicationForm < Superform::Rails::Form
 end
 ```
 
-That looks like a LOT of code, and it is, but look at how easy it is to create forms.
+That looks like a LOT of code, and it is, but look at how easy it is to create
+forms.
 
 ```ruby
 # ./app/views/users/form.rb
@@ -133,9 +137,12 @@ Much better!
 
 ## Namespaces & Collections
 
-Superform uses a different syntax for namespacing and collections than Rails, which can be a bit confusing since the same terminology is used but the application is slightly different.
+Superform uses a different syntax for namespacing and collections than Rails,
+which can be a bit confusing since the same terminology is used but the
+application is slightly different.
 
-Consider a form for an account that lets people edit the names and email of the owner and users of an account.
+Consider a form for an account that lets people edit the names and email of the
+owner and users of an account.
 
 ```ruby
 class AccountForm < Superform::Rails::Form
@@ -184,7 +191,8 @@ There's three different types of namespaces and collections to consider:
 
 ### Change a form's root namespace
 
-By default Superform namespaces a form based on the ActiveModel model name param key.
+By default Superform will namespace a form based on the ActiveModel model name
+param key.
 
 ```ruby
 class UserForm < Superform::Rails::Form
@@ -200,7 +208,8 @@ render LoginForm.new(Admin::User.new)
 # Renders input with the name `admin_user[email]`
 ```
 
-To customize the form namespace, like an ActiveRecord model nested within a module, the `key` method can be overriden.
+If you want to customize the form namespace, you can override the `key` method
+in your form.
 
 ```ruby
 class UserForm < Superform::Rails::Form
@@ -222,9 +231,13 @@ render UserForm.new(Admin::User.new)
 
 ## Form field guide
 
-Superform tries to strike a balance between "being as close to HTML forms as possible" and not requiring a lot of boilerplate to create forms. This example is contrived, but it shows all the different ways you can render a form.
+Superform tries to strike a balance between "being as close to HTML forms as
+possible" and not requiring a lot of boilerplate to create forms. This example
+is contrived, but it shows all the different ways you can render a form.
 
-In practice, many of the calls below you'd put inside of a method. This cuts down on the number of `render` calls in your HTML code and further reduces boilerplate.
+In practice, many of the calls below you'd put inside of a method. This cuts
+down on the number of `render` calls in your HTML code and further reduces
+boilerplate.
 
 ```ruby
 # Everything below is intentionally verbose!
@@ -234,7 +247,11 @@ class SignupForm < ApplicationForm
     render field(:name).input.focus
 
     # Input field with a lot more options on it.
-    render field(:email).input(type: :email, placeholder: "We will sell this to third parties", required: true)
+    render field(:email).input(
+        type: :email,
+        placeholder: "We will sell this to third parties",
+        required: true
+    )
 
     # You can put fields in a block if that's your thing.
     render field(:reason) do |f|
@@ -258,8 +275,9 @@ class SignupForm < ApplicationForm
     div do
       render field(:source).label { "How did you hear about us?" }
       render field(:source).select do |s|
-        # Pretend WebSources is an ActiveRecord scope with a "Social" category that has "Facebook, X, etc"
-        # and a "Search" category with "AltaVista, Yahoo, etc."
+        # Pretend WebSources is an ActiveRecord scope with a "Social"
+        # category that has "Facebook, X, etc" and a "Search" category
+        # with "AltaVista, Yahoo, etc."
         WebSources.select(:id, :name).group_by(:category) do |category, sources|
           s.optgroup(label: category) do
             s.options(sources)
@@ -269,7 +287,9 @@ class SignupForm < ApplicationForm
     end
 
     div do
-      render field(:agreement).label { "Check this box if you agree to give us your first born child" }
+      render field(:agreement).label do
+        "Check this box if you agree to give us your first born child"
+      end
       render field(:agreement).checkbox(checked: true)
     end
 
@@ -281,7 +301,8 @@ end
 
 ## Extending Superforms
 
-The best part? If you have forms with a completely different look and feel, you can extend the forms just like you would a Ruby class:
+The best part? If you have forms with a completely different look and feel, you
+can extend the forms just like you would a Ruby class:
 
 ```ruby
 class AdminForm < ApplicationForm
@@ -313,11 +334,19 @@ class Admin::Users::Form < AdminForm
 end
 ```
 
-Since Superforms are just Ruby objects, you can organize them however you want. You can keep your view component classes embedded in your Superform file if you prefer for everything to be in one place, keep the forms in the `app/views/forms/*.rb` folder and the components in `app/views/forms/**/*_component.rb`, use Ruby's `include` and `extend` features to modify different form classes, or put them in a gem and share them with an entire organization or open source community. It's just Ruby code!
+Since Superforms are just Ruby objects, you can organize them however you want.
+You can keep your view component classes embedded in your Superform file if you
+prefer for everything to be in one place, keep the forms in the
+`app/views/forms/*.rb` folder and the components in
+`app/views/forms/**/*_component.rb`, use Ruby's `include` and `extend` features
+to modify different form classes, or put them in a gem and share them with an
+entire organization or open source community. It's just Ruby code!
 
 ## Automatic strong parameters
 
-Guess what? Superform eliminates the need for Strong Parameters in Rails by assigning the values of the `params` hash _through_ your form via the `assign` method. Here's what it looks like.
+Guess what? Superform eliminates the need for Strong Parameters in Rails by
+assigning the values of the `params` hash _through_ your form via the `assign`
+method. Here's what it looks like.
 
 ```ruby
 class PostsController < ApplicationController
@@ -347,39 +376,69 @@ class PostsController < ApplicationController
 end
 ```
 
-How does it work? An instance of the form is created, then the hash is assigned to it. If the params include data outside of what a form accepts, it will be ignored.
+How does it work? An instance of the form is created, then the hash is assigned
+to it. If the params include data outside of what a form accepts, it will be
+ignored.
 
 ## Comparisons
 
-Rails ships with a lot of great options to make forms. Many of these inspired Superform. The tl;dr:
+Rails ships with a lot of great options to make forms. Many of these inspired
+Superform. The tl;dr:
 
-1. Rails has a lot of great form helpers. Simple Form and Formtastic both have concise ways of defining HTML forms, but do require frequently opening and closing Erb tags.
+1. Rails has a lot of great form helpers. Simple Form and Formtastic both have
+   concise ways of defining HTML forms, but do require frequently opening and
+   closing Erb tags.
 
-2. Superform is uniquely capable of permitting its own controller parameters, leaving you with one less thing to worry about and test. Additionally it can be extended, shared, and modularized since its Plain' 'ol Ruby, which opens up a world of TailwindCSS form libraries and proprietary form libraries developed internally by organizations.
+2. Superform is uniquely capable of permitting its own controller parameters,
+   leaving you with one less thing to worry about and test. Additionally it can
+   be extended, shared, and modularized since its Plain' 'ol Ruby, which opens
+   up a world of TailwindCSS form libraries and proprietary form libraries
+   developed internally by organizations.
 
 ### Rails form helpers
 
-Rails form helpers have lasted for almost 20 years and are super solid, but things get tricky when your application starts to take on different styles of forms. To manage it all you have to cobble together helper methods, partials, and templates. Additionally, the structure of the form then has to be expressed to the controller as strong params, forcing you to repeat yourself.
+Rails form helpers have lasted for almost 20 years and are super solid, but
+things get tricky when your application starts to take on different styles of
+forms. To manage it all you have to cobble together helper methods, partials,
+and templates. Additionally, the structure of the form then has to be expressed
+to the controller as strong params, forcing you to repeat yourself.
 
-With Superform, you build the entire form with Ruby code, so you avoid the Erb gymnastics and helper method soup that it takes in Rails to scale up forms in an organization.
+With Superform, you build the entire form with Ruby code, so you avoid the Erb
+gymnastics and helper method soup that it takes in Rails to scale up forms in an
+organization.
 
 ### Simple Form
 
-I built some pretty amazing applications with Simple Form and admire its syntax. It requires "Erb soup", which is an opening and closing line of Erb per line. If you follow a specific directory structure or use their component framework, you can get pretty far, but you'll hit a wall when you need to start putting wrappers around forms or inputs.
+I built some pretty amazing applications with Simple Form and admire its syntax.
+It requires "Erb soup", which is an opening and closing line of Erb per line. If
+you follow a specific directory structure or use their component framework, you
+can get pretty far, but you'll hit a wall when you need to start putting
+wrappers around forms or inputs.
 
-https://github.com/heartcombo/simple_form#the-wrappers-api
+[https://github.com/heartcombo/simple\_form#the-wrappers-api](
+  https://github.com/heartcombo/simple_form#the-wrappers-api
+)
 
-The API is there, but when you change the syntax, you have to reboot the server to see the changes. UI development should be reflected immediately when the page is reloaded, which is what Superforms can do.
+The API is there, but when you change the syntax, you have to reboot the server
+to see the changes. UI development should be reflected immediately when the page
+is reloaded, which is what Superforms can do.
 
 Like Rails form helpers, it doesn't self-permit parameters.
 
-https://www.ruby-toolbox.com/projects/simple_form
+[https://www.ruby-toolbox.com/projects/simple\_form](
+  https://www.ruby-toolbox.com/projects/simple_form
+)
 
 ### Formtastic
 
-Formtastic gives us a nice DSL inside of Erb that we can use to create forms, but like Simple Form, there's a lot of opening and closing Erb tags that make the syntax clunky.
+Formtastic gives us a nice DSL inside of Erb that we can use to create forms,
+but like Simple Form, there's a lot of opening and closing Erb tags that make
+the syntax clunky.
 
-It has generators that give you Ruby objects that represent HTML form inputs that you can customize, but its limited to very specific parts of the HTML components. Superform lets you customize every aspect of the HTML in your form elements.
+It has generators that give you Ruby objects that represent HTML form inputs
+that you can customize, but its limited to very specific parts of the HTML
+components. Superform lets you customize every aspect of the HTML in your form
+elements.
 
 It also does not permit its own parameters.
 
@@ -387,18 +446,31 @@ https://www.ruby-toolbox.com/projects/formtastic
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run
+`rake spec` to run the tests. You can also run `bin/console` for an interactive
+prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`. To
+release a new version, update the version number in `version.rb`, and then run
+`bundle exec rake release`, which will create a git tag for the version, push
+git commits and the created tag, and push the `.gem` file to
+[rubygems.org](https://rubygems.org).
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/rubymonolith/superform. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/rubymonolith/superform/blob/main/CODE_OF_CONDUCT.md).
+Bug reports and pull requests are welcome on GitHub at
+https://github.com/rubymonolith/superform. This project is intended to be
+a safe, welcoming space for collaboration, and contributors are expected to
+adhere to the [code of
+conduct](https://github.com/rubymonolith/superform/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+The gem is available as open source under the terms of the
+[MIT License](https://opensource.org/licenses/MIT).
 
 ## Code of Conduct
 
-Everyone interacting in the Superform project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/rubymonolith/superform/blob/main/CODE_OF_CONDUCT.md).
+Everyone interacting in the Superform project's codebases, issue trackers, chat
+rooms and mailing lists is expected to follow the
+[code of conduct](https://github.com/rubymonolith/superform/blob/main/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -1,16 +1,29 @@
 # Superform
 
-Superform aims to be the best way to build forms in Rails applications. Here's what it does differently.
+Superform aims to be the best way to build forms in Rails applications. Here's
+what it does differently.
 
-* **Everything is a component.** Superform is built on top of [Phlex](https://phlex.fun), so every bit of HTML in the form can be customized to your precise needs. Use it with your own CSS Framework or go crazy customizing every last bit of TailwindCSS.
+* **Everything is a component.** Superform is built on top of
+  [Phlex](https://phlex.fun), so every bit of HTML in the form can be customized
+  to your precise needs. Use it with your own CSS Framework or go crazy
+  customizing every last bit of TailwindCSS.
 
-* **Automatic strong parameters.** Superform automatically permits form fields so you don't have to facepalm yourself after adding a field, wondering why it doesn't persist, only to realize you forgot to add the parameter to your controller. No more! Superform was architected with safety & security in mind, meaning it can automatically permit your form parameters.
+* **Automatic strong parameters.** Superform automatically permits form fields
+  so you don't have to facepalm yourself after adding a field, wondering why it
+  doesn't persist, only to realize you forgot to add the parameter to your
+  controller. No more! Superform was architected with safety & security in mind,
+  meaning it can automatically permit your form parameters.
 
-* **Compose complex forms with Plain 'ol Ruby Objects.** Superform is built on top of POROs, so you can easily compose classes, modules, & ruby code together to create complex forms. You can even extend forms to create new forms with a different look and feel.
+* **Compose complex forms with Plain 'ol Ruby Objects.** Superform is built on
+  top of POROs, so you can easily compose classes, modules, & ruby code together
+  to create complex forms. You can even extend forms to create new forms with
+  a different look and feel.
 
-It's a complete rewrite of Rails form's internals that's inspired by Reactive component design patterns.
+It's a complete rewrite of Rails form's internals that's inspired by Reactive
+component design patterns.
 
-[![Maintainability](https://api.codeclimate.com/v1/badges/0e4dfe2a1ece26e3a59e/maintainability)](https://codeclimate.com/github/rubymonolith/superform/maintainability) [![Ruby](https://github.com/rubymonolith/superform/actions/workflows/main.yml/badge.svg)](https://github.com/rubymonolith/superform/actions/workflows/main.yml)
+[![Maintainability](https://api.codeclimate.com/v1/badges/0e4dfe2a1ece26e3a59e/maintainability)](https://codeclimate.com/github/rubymonolith/superform/maintainability)
+[![Ruby](https://github.com/rubymonolith/superform/actions/workflows/main.yml/badge.svg)](https://github.com/rubymonolith/superform/actions/workflows/main.yml)
 
 ## Installation
 
@@ -26,9 +39,15 @@ This will install both Phlex Rails and Superform.
 
 ## Usage
 
-Superform streamlines the development of forms on Rails applications by making everything a component.
+Superform streamlines the development of forms on Rails applications by making
+everything a Phlex component.
 
-After installing, create a form in `app/views/*/form.rb`. For example, a form for a `Post` resource might look like this.
+They are designed to work like the form builders you are already used to. You
+can pass a model and it will infer attributes like `method` and `action`. These
+can be overridden by passing arguments when initializing the component.
+
+After installing, create a form in `app/views/*/form.rb`. For example, a form
+for a `Post` resource might look like this.
 
 ```ruby
 # ./app/views/posts/form.rb
@@ -45,7 +64,15 @@ Then render it in your templates. Here's what it looks like from an Erb file.
 
 ```erb
 <h1>New post</h1>
-<%= render Posts::Form.new @post %>
+<%= render Posts::Form.new(
+    @post,
+    # These options are inferred from the model but can be overwritten
+    # just like your regular rails forms
+    action: new_post_path,
+    method: :post,
+    # Other html attributes can be passed in too
+    data: { controller: "some_stimulus_controller" }
+) %>
 ```
 
 ## Customization

--- a/README.md
+++ b/README.md
@@ -70,10 +70,14 @@ Then render it in your templates. Here's what it looks like from an Erb file.
     # just like your regular rails forms
     action: new_post_path,
     method: :post,
-    # Other html attributes can be passed in too
+    # Other html attributes can be passed in as keyword arguments
     data: { controller: "some_stimulus_controller" }
 ) %>
 ```
+
+At minimum your model should implement `ActiveModel::Naming` and respond to
+`persisted?`. Including either `ActiveModel::Model` or `ActiveModel::API` is
+a common way to meet these requirements for plain old ruby objects.
 
 ## Customization
 
@@ -113,7 +117,7 @@ end
 ```
 
 That looks like a LOT of code, and it is, but look at how easy it is to create
-forms.
+forms:
 
 ```ruby
 # ./app/views/users/form.rb
@@ -127,7 +131,7 @@ class Users::Form < ApplicationForm
 end
 ```
 
-Then render it from Erb.
+Then render it from Erb:
 
 ```erb
 <%= render Users::Form.new @user %>
@@ -297,7 +301,6 @@ class SignupForm < ApplicationForm
   end
 end
 ```
-
 
 ## Extending Superforms
 


### PR DESCRIPTION
I formatted the markdown files for line length and added some documentation:
- Shows how to customize `action` and `method` on the form
- Shows how to use plain old ruby objects as form objects, minimum to implement