### PR TITLE
Fixes _method_field_value boolean evaluation

### DIFF
--- a/lib/superform/rails.rb
+++ b/lib/superform/rails.rb
@@ -128,7 +128,7 @@ module Superform
         end
 
         def _method_field_value
-          @method || @model.persisted? ? "patch" : "post"
+          @method || (@model.persisted? ? "patch" : "post")
         end
 
         def submit_value

--- a/lib/superform/rails.rb
+++ b/lib/superform/rails.rb
@@ -128,7 +128,11 @@ module Superform
         end
 
         def _method_field_value
-          @method || (@model.persisted? ? "patch" : "post")
+          @method || resource_method_field_value
+        end
+
+        def resource_method_field_value
+          @model.persisted? ? "patch" : "post"
         end
 
         def submit_value


### PR DESCRIPTION
Currently `_method_field_value` looks like:

```ruby
def _method_field_value
  @method || @model.persisted? ? "patch" : "post"
end
```

Which evaluates as `x ? "patch" : "post"` instead of `x || y ? "patch" : "post`

Putting () around the second term fixes it and allows overriding the method to work.