### PR TITLE
Adds check for file type on input before setting value

### DIFF
--- a/lib/superform/rails.rb
+++ b/lib/superform/rails.rb
@@ -272,7 +272,17 @@ module Superform
         end
 
         def field_attributes
-          { id: dom.id, name: dom.name, value: dom.value, type: type }
+          {
+            id: dom.id,
+            name: dom.name,
+            type: type
+          }.tap do |attrs|
+            attrs[:value] = field.value if value?
+          end
+        end
+
+        def value?
+          @attributes[:type] != "file"
         end
 
         def type

--- a/lib/superform/rails.rb
+++ b/lib/superform/rails.rb
@@ -275,14 +275,22 @@ module Superform
           {
             id: dom.id,
             name: dom.name,
-            type: type
-          }.tap do |attrs|
-            attrs[:value] = field.value if value?
+            type: type,
+            value: value
+          }
+        end
+
+        def client_provided_value?
+          case type
+          when "file", "image"
+            false
+          else
+            true
           end
         end
 
-        def value?
-          @attributes[:type] != "file"
+        def value
+          dom.value unless client_provided_value?
         end
 
         def type


### PR DESCRIPTION
Currently ActiveStorage attachments are outputting their value onto the field which gives some awkward errors like:

```
<ActiveStorage::Attached::One#8201> file is missing
```

Its caused by the `value` attribute on the field being set to the attachment object `to_str`.

This commit adds a check for whether or not the input is a file before applying the value to the field.