### PR TITLE
Improves select

### DIFF
--- a/lib/superform/rails.rb
+++ b/lib/superform/rails.rb
@@ -349,6 +349,7 @@ module Superform
           def field_attributes
             super.merge(
               name: @multiple ? "#{dom.name}[]" : dom.name,
+              multiple: @multiple
             )
           end
 

--- a/lib/superform/rails.rb
+++ b/lib/superform/rails.rb
@@ -299,16 +299,30 @@ module Superform
       end
 
       class SelectField < FieldComponent
-        def initialize(*, collection: [], **, &)
+        def initialize(
+          *,
+          collection: [],
+          multiple: false,
+          include_blank: false,
+          **,
+          &
+        )
           super(*, **, &)
           @collection = collection
+          @multiple = multiple
+          @include_blank = include_blank
         end
 
         def template(&options)
+          input(type: "hidden", name: dom.name, value: "") if @multiple
+
           if block_given?
             select(**attributes, &options)
           else
-            select(**attributes) { options(*@collection) }
+            select(**attributes) do
+              blank_option if @include_blank
+              options(*@collection)
+            end
           end
         end
 

--- a/lib/superform/rails.rb
+++ b/lib/superform/rails.rb
@@ -345,6 +345,13 @@ module Superform
         end
 
         protected
+
+          def field_attributes
+            super.merge(
+              name: @multiple ? "#{dom.name}[]" : dom.name,
+            )
+          end
+
           def map_options(collection)
             OptionMapper.new(collection)
           end


### PR DESCRIPTION
This branch adds a few core features to select according to https://apidock.com/rails/ActionView/Helpers/FormOptionsHelper/select

- Adds `include_blank` keyword that adds a blank option
- Adds `multiple` keyword that changes `name` to add `[]` if mutliple is true
- Adds hidden input to select elements to handle the way browsers handle blank selects

Relevant part from the link above:


> The [HTML](https://apidock.com/rails/HTML) specification says when multiple parameter passed to [select](https://apidock.com/rails/ActionView/Helpers/FormOptionsHelper/select) and all options got deselected web browsers do not send any value to server. Unfortunately this introduces a gotcha: if a [User](https://apidock.com/rails/User) model has many roles and have role_ids accessor, and in the form that edits roles of the user the user deselects all roles from role_ids multiple [select](https://apidock.com/rails/ActionView/Helpers/FormOptionsHelper/select) box, no role_ids parameter is sent. So, any mass-assignment idiom like