### PR TITLE
Forward field class

### DIFF
--- a/lib/superform/namespace.rb
+++ b/lib/superform/namespace.rb
@@ -69,7 +69,7 @@ module Superform
     # The object within the block is a `Namespace` object that maps each object within the enumerable
     # to another `Namespace` or `Field`.
     def collection(key, &)
-      create_child(key, NamespaceCollection, &)
+      create_child(key, NamespaceCollection, field_class: @field_class, &)
     end
 
     # Creates a Hash of Hashes and Arrays that represent the fields and collections of the Superform.

--- a/lib/superform/namespace.rb
+++ b/lib/superform/namespace.rb
@@ -34,7 +34,7 @@ module Superform
     # end
     # ```
     def namespace(key, &block)
-      create_child(key, self.class, object: object_for(key: key), &block)
+      create_child(key, self.class, object: object_for(key: key), field_class: @field_class, &block)
     end
 
     # Maps the `Object#proprety` and `Object#property=` to a field in a web form that can be

--- a/lib/superform/namespace_collection.rb
+++ b/lib/superform/namespace_collection.rb
@@ -5,8 +5,9 @@ module Superform
   class NamespaceCollection < Node
     include Enumerable
 
-    def initialize(key, parent:, &template)
+    def initialize(key, parent:, field_class: Field, &template)
       super(key, parent: parent)
+      @field_class = field_class
       @template = template
       @namespaces = enumerate(parent_collection)
     end
@@ -38,7 +39,7 @@ module Superform
     end
 
     def build_namespace(index, **)
-      parent.class.new(index, parent: self, **, &@template)
+      parent.class.new(index, parent: self, field_class: @field_class, **, &@template)
     end
 
     def parent_collection

--- a/spec/superform/namespace_collection_spec.rb
+++ b/spec/superform/namespace_collection_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Superform::NamespaceCollection do
     it "creates an indexed namespace for each item" do
       object.bars.each.with_index do |bar, index|
         expect(Superform::Namespace).to receive(:new).with(
-          index, parent: collection, object: bar
+          index, parent: collection, object: bar, field_class: Superform::Field
         ).ordered
       end
 
@@ -31,6 +31,24 @@ RSpec.describe Superform::NamespaceCollection do
         an_object_satisfying { |item| item.is_a?(Superform::Namespace) && item.key == 0 },
         an_object_satisfying { |item| item.is_a?(Superform::Namespace) && item.key == 1 }
       )
+    end
+
+    context "with another field_class" do
+      subject(:collection) do
+        described_class.new(:bars, parent: namespace, field_class: Superform::Rails::Form::Field) do |collection|
+          collection.field(:baz)
+        end
+      end
+
+      it "creates an indexed namespace for each item, with the collection field_class" do
+        object.bars.each.with_index do |bar, index|
+          expect(Superform::Namespace).to receive(:new).with(
+            index, parent: collection, object: bar, field_class: Superform::Rails::Form::Field
+          ).ordered
+        end
+
+        collection.each.to_a
+      end
     end
   end
 

--- a/spec/superform/namespace_collection_spec.rb
+++ b/spec/superform/namespace_collection_spec.rb
@@ -1,18 +1,41 @@
 RSpec.describe Superform::NamespaceCollection do
-  describe "#assign" do
-    it "assigns the value to each namespace" do
-      object = OpenStruct.new(
-        bars: [
-          OpenStruct.new(baz: "A"),
-          OpenStruct.new(baz: "B")
-        ]
-      )
+  subject(:collection) do
+    described_class.new(:bars, parent: namespace) do |collection|
+      collection.field(:baz)
+    end
+  end
 
-      namespace = Superform::Namespace.new(:foo, parent: nil, object:)
-      collection = described_class.new(:bars, parent: namespace) do |collection|
-        collection.field(:baz)
+  let(:namespace) { Superform::Namespace.new(:foo, parent: nil, object: object) }
+  let(:object) do
+    OpenStruct.new(
+      bars: [
+        OpenStruct.new(baz: "A"),
+        OpenStruct.new(baz: "B")
+      ]
+    )
+  end
+
+  describe "each" do
+    it "creates an indexed namespace for each item" do
+      object.bars.each.with_index do |bar, index|
+        expect(Superform::Namespace).to receive(:new).with(
+          index, parent: collection, object: bar
+        ).ordered
       end
 
+      collection.each.to_a
+    end
+
+    it "yields a namespace for each collection item" do
+      expect { |b| collection.each(&b) }.to yield_successive_args(
+        an_object_satisfying { |item| item.is_a?(Superform::Namespace) && item.key == 0 },
+        an_object_satisfying { |item| item.is_a?(Superform::Namespace) && item.key == 1 }
+      )
+    end
+  end
+
+  describe "#assign" do
+    it "assigns the value to each namespace" do
       collection.assign([{ baz: "C" },{ baz: "D" }])
       expect(collection.serialize).to eq([{ baz: "C" },{ baz: "D" }])
     end

--- a/spec/superform/namespace_spec.rb
+++ b/spec/superform/namespace_spec.rb
@@ -7,6 +7,21 @@ RSpec.describe Superform::Namespace do
         expect(child.key).to eq(:bar)
       end
     end
+
+    context 'with a given field_class' do
+      before do
+        allow(described_class).to receive(:new).and_call_original
+      end
+
+      it "forwards the fields_class to the child namespace" do
+        parent = described_class.new(:foo, parent: nil, field_class: Superform::Rails::Form::Field)
+
+        expect(described_class).to receive(:new).with(:bar,
+                                                      parent:, object: nil, field_class: Superform::Rails::Form::Field)
+
+        parent.namespace(:bar)
+      end
+    end
   end
 
   describe "#field" do
@@ -15,6 +30,16 @@ RSpec.describe Superform::Namespace do
       parent.field(:bar) do |child|
         expect(child).to be_a(Superform::Field)
         expect(child.key).to eq(:bar)
+      end
+    end
+
+    context 'with a given field_class' do
+      it "builds a field of the given class" do
+        parent = described_class.new(:foo, parent: nil, object: nil, field_class: Superform::Rails::Form::Field)
+        parent.field(:bar) do |child|
+          expect(child).to be_a(Superform::Rails::Form::Field)
+          expect(child.key).to eq(:bar)
+        end
       end
     end
   end


### PR DESCRIPTION
I tried to get to the core of the problem and only deal with the field_class being properly propagated, so that the Superform::Rails::Form::Field can actually be used. I kept the specs close to the adjustments made.
I did not deal with field_class attr_reader, as is seems like something that could remain an internal detail for now with this change.