### PR TITLE
Use kwargs for Rails::Components::BaseComponent

### DIFF
--- a/lib/superform/rails.rb
+++ b/lib/superform/rails.rb
@@ -45,28 +45,28 @@ module Superform
       #
       # Now all calls to `label` will have the `text-bold` class applied to it.
       class Field < Superform::Field
-        def button(**attributes)
-          Components::ButtonComponent.new(self, attributes: attributes)
+        def button(...)
+          Components::ButtonComponent.new(self, ...)
         end
 
-        def input(**attributes)
-          Components::InputComponent.new(self, attributes: attributes)
+        def input(...)
+          Components::InputComponent.new(self, ...)
         end
 
-        def checkbox(**attributes)
-          Components::CheckboxComponent.new(self, attributes: attributes)
+        def checkbox(...)
+          Components::CheckboxComponent.new(self, ...)
         end
 
-        def label(**attributes, &)
-          Components::LabelComponent.new(self, attributes: attributes, &)
+        def label(...)
+          Components::LabelComponent.new(self, ...)
         end
 
-        def textarea(**attributes)
-          Components::TextareaComponent.new(self, attributes: attributes)
+        def textarea(...)
+          Components::TextareaComponent.new(self, ...)
         end
 
         def select(*collection, **attributes, &)
-          Components::SelectField.new(self, attributes: attributes, collection: collection, &)
+          Components::SelectField.new(self, collection: collection, **attributes, &)
         end
 
         def title
@@ -203,7 +203,7 @@ module Superform
 
         delegate :dom, to: :field
 
-        def initialize(field, attributes: {})
+        def initialize(field, **attributes)
           @field = field
           @attributes = attributes
         end

--- a/spec/superform/rails/components/base_component_spec.rb
+++ b/spec/superform/rails/components/base_component_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Superform::Rails::Components::BaseComponent do
+  class CustomComponent < described_class
+    def view_template
+      input(**attributes)
+    end
+  end
+
+  subject(:component) { CustomComponent.new(field, type: 'text') }
+
+  let(:field) { described_class.new(:foo, parent: nil, object:) }
+  let(:object) { double('Foo', bar: 'baz') }
+
+  it 'reads the attributes' do
+    expect(component).to receive(:input).with(type: 'text')
+
+    component.call
+  end
+end

--- a/spec/superform/rails/components/input_component_spec.rb
+++ b/spec/superform/rails/components/input_component_spec.rb
@@ -1,6 +1,9 @@
 RSpec.describe Superform::Rails::Components::InputComponent do
+  subject(:component) do
+    described_class.new(field, **attributes)
+  end
+
   let(:field) do
-    object = double("object", "foo=": nil)
     object = double("object", "foo": value)
     Superform::Field.new(:foo, parent: nil, object:)
   end
@@ -10,10 +13,6 @@ RSpec.describe Superform::Rails::Components::InputComponent do
   let(:attributes) do
     {}
   end
-  let(:component) do
-    described_class.new(field, attributes: attributes)
-  end
-  subject { component }
 
   it { is_expected.to_not have_client_provided_value }
   it "is type: :text by default" do

--- a/spec/superform/rails/form/field_spec.rb
+++ b/spec/superform/rails/form/field_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe Superform::Rails::Form::Field do
+  let(:field) { described_class.new(:foo, parent: nil, object:) }
+  let(:object) { double('Foo', bar: 'baz') }
+
+  let(:attributes) do
+    { class: %[a b], role: 'element' }
+  end
+  let(:template) { proc { 'baz' } }
+
+  it { expect(field).to be_a(Superform::Field) }
+
+  { input: 'InputComponent', label: 'LabelComponent', button: 'ButtonComponent',
+    checkbox: 'CheckboxComponent', textarea: 'TextareaComponent' }.each do |method, klass|
+    describe method.to_s do
+      it "delegates to #{klass}" do
+        component_class = Superform::Rails::Components.const_get(klass)
+
+        expect(component_class).to receive(:new).with(field, **attributes, &template)
+
+        field.send(method, **attributes, &template)
+      end
+    end
+  end
+
+  describe 'select' do
+    it 'delegates to SelectField component' do
+      expect(Superform::Rails::Components::SelectField).to receive(:new).with(
+        field, collection: [], **attributes, &template
+      )
+
+      field.select(**attributes, &template)
+    end
+  end
+end


### PR DESCRIPTION
Keeping it uniform with Rails::Form. This gives more flexibility for arguments by default, while still allowing the attributes: keyword. Suports partial destructuring, thus preventing manual wrapping / unpacking of options.

[#54]