### PR TITLE
Checkbox - allow collections, add Radio component

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
     drb (2.2.1)
     erubi (1.13.1)
     ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x86_64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
     formatador (1.1.0)
     globalid (1.2.1)
@@ -145,6 +146,8 @@ GEM
       net-protocol
     nio4r (2.7.4)
     nokogiri (1.18.9-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.9-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.9-x86_64-linux-gnu)
       racc (~> 1.4)
@@ -233,6 +236,7 @@ GEM
     securerandom (0.3.1)
     shellany (0.0.1)
     sqlite3 (2.7.3-arm64-darwin)
+    sqlite3 (2.7.3-x86_64-darwin)
     sqlite3 (2.7.3-x86_64-linux-gnu)
     stringio (3.1.1)
     thor (1.3.2)
@@ -252,6 +256,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   arm64-darwin-24
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ class SignupForm < Components::Form
 
     # Radio buttons - for single-select from multiple options
     div do
-      Field(:plan).label { "Choose your plan" }
+      Field(:plan).label(for: false) { "Choose your plan" }
       # Pass options as positional arguments
       Field(:plan).radio(
         ["free", "Free Plan"],      # <label><input type="radio" value="free">Free Plan</label>
@@ -372,7 +372,7 @@ class SignupForm < Components::Form
 
     # Or render individual radio buttons with custom markup
     div do
-      Field(:gender).label { "Gender" }
+      Field(:gender).label(for: false) { "Gender" }
       Field(:gender).radio do |r|
         div { r.option("m") { "Male" } }
         div { r.option("f") { "Female" } }
@@ -386,9 +386,9 @@ class SignupForm < Components::Form
       Field(:agreement).checkbox(checked: true)
     end
 
-    # Checkbox collection - for multi-select from multiple options
+    # Checkbox array - for multi-select from multiple options
     div do
-      Field(:role_ids).label { "Select your roles" }
+      Field(:role_ids).label(for: false) { "Select your roles" }
       # Pass options as positional arguments (similar to radio)
       Field(:role_ids).checkbox(
         [1, "Admin"],   # <label><input type="checkbox" value="1">Admin</label>
@@ -399,7 +399,7 @@ class SignupForm < Components::Form
 
     # Or render individual checkboxes with custom markup
     div do
-      Field(:feature_ids).label { "Enable features" }
+      Field(:feature_ids).label(for: false) { "Enable features" }
       Field(:feature_ids).checkbox do |c|
         div { c.option(1) { "Dark Mode" } }
         div { c.option(2) { "Notifications" } }
@@ -409,13 +409,13 @@ class SignupForm < Components::Form
 
     # Both radio and checkbox support ActiveRecord relations
     div do
-      Field(:category_id).label { "Select category" }
+      Field(:category_id).label(for: false) { "Select category" }
       # Automatically uses id as value and name as label
       Field(:category_id).radio(Category.select(:id, :name))
     end
 
     div do
-      Field(:tag_ids).label { "Select tags" }
+      Field(:tag_ids).label(for: false) { "Select tags" }
       # Automatically uses id as value and name as label
       Field(:tag_ids).checkbox(Tag.select(:id, :name))
     end

--- a/README.md
+++ b/README.md
@@ -359,10 +359,10 @@ class SignupForm < Components::Form
       end
     end
 
-    # Radio buttons can be rendered individually or as a collection
+    # Radio buttons can be rendered individually or as a group
     div do
       Field(:plan).label { "Choose your plan" }
-      # Radio collection with options - renders multiple radio buttons
+      # Radio group with options - renders multiple radio buttons
       Field(:plan).radio(
         options: [
           ["free", "Free Plan"],     # <input type="radio" value="free">Free Plan

--- a/README.md
+++ b/README.md
@@ -359,16 +359,14 @@ class SignupForm < Components::Form
       end
     end
 
-    # Radio buttons can be rendered individually or as a group
+    # Radio buttons - for single-select from multiple options
     div do
       Field(:plan).label { "Choose your plan" }
-      # Radio group with options - renders multiple radio buttons
+      # Pass options as positional arguments
       Field(:plan).radio(
-        options: [
-          ["free", "Free Plan"],     # <input type="radio" value="free">Free Plan
-          ["pro", "Pro Plan"],       # <input type="radio" value="pro">Pro Plan
-          ["enterprise", "Enterprise"] # <input type="radio" value="enterprise">Enterprise
-        ]
+        ["free", "Free Plan"],      # <label><input type="radio" value="free">Free Plan</label>
+        ["pro", "Pro Plan"],        # <label><input type="radio" value="pro">Pro Plan</label>
+        ["enterprise", "Enterprise"] # <label><input type="radio" value="enterprise">Enterprise</label>
       )
     end
 
@@ -382,9 +380,44 @@ class SignupForm < Components::Form
       end
     end
 
+    # Boolean checkbox - single true/false toggle
     div do
       Field(:agreement).label { "Check this box if you agree to give us your first born child" }
       Field(:agreement).checkbox(checked: true)
+    end
+
+    # Checkbox collection - for multi-select from multiple options
+    div do
+      Field(:role_ids).label { "Select your roles" }
+      # Pass options as positional arguments (similar to radio)
+      Field(:role_ids).checkbox(
+        [1, "Admin"],   # <label><input type="checkbox" value="1">Admin</label>
+        [2, "Editor"],  # <label><input type="checkbox" value="2">Editor</label>
+        [3, "Viewer"]   # <label><input type="checkbox" value="3">Viewer</label>
+      )
+    end
+
+    # Or render individual checkboxes with custom markup
+    div do
+      Field(:feature_ids).label { "Enable features" }
+      Field(:feature_ids).checkbox do |c|
+        div { c.button(1) { "Dark Mode" } }
+        div { c.button(2) { "Notifications" } }
+        div { c.button(3) { "Auto-save" } }
+      end
+    end
+
+    # Both radio and checkbox support ActiveRecord relations
+    div do
+      Field(:category_id).label { "Select category" }
+      # Automatically uses id as value and name as label
+      Field(:category_id).radio(Category.select(:id, :name))
+    end
+
+    div do
+      Field(:tag_ids).label { "Select tags" }
+      # Automatically uses id as value and name as label
+      Field(:tag_ids).checkbox(Tag.select(:id, :name))
     end
 
     render button { "Submit" }

--- a/README.md
+++ b/README.md
@@ -359,6 +359,29 @@ class SignupForm < Components::Form
       end
     end
 
+    # Radio buttons can be rendered individually or as a collection
+    div do
+      Field(:plan).label { "Choose your plan" }
+      # Radio collection with options - renders multiple radio buttons
+      Field(:plan).radio(
+        options: [
+          ["free", "Free Plan"],     # <input type="radio" value="free">Free Plan
+          ["pro", "Pro Plan"],       # <input type="radio" value="pro">Pro Plan
+          ["enterprise", "Enterprise"] # <input type="radio" value="enterprise">Enterprise
+        ]
+      )
+    end
+
+    # Or render individual radio buttons with custom markup
+    div do
+      Field(:gender).label { "Gender" }
+      Field(:gender).radio do |r|
+        div { r.button("m") { "Male" } }
+        div { r.button("f") { "Female" } }
+        div { r.button("o") { "Other" } }
+      end
+    end
+
     div do
       Field(:agreement).label { "Check this box if you agree to give us your first born child" }
       Field(:agreement).checkbox(checked: true)

--- a/README.md
+++ b/README.md
@@ -401,9 +401,9 @@ class SignupForm < Components::Form
     div do
       Field(:feature_ids).label { "Enable features" }
       Field(:feature_ids).checkbox do |c|
-        div { c.button(1) { "Dark Mode" } }
-        div { c.button(2) { "Notifications" } }
-        div { c.button(3) { "Auto-save" } }
+        div { c.option(1) { "Dark Mode" } }
+        div { c.option(2) { "Notifications" } }
+        div { c.option(3) { "Auto-save" } }
       end
     end
 

--- a/README.md
+++ b/README.md
@@ -374,9 +374,9 @@ class SignupForm < Components::Form
     div do
       Field(:gender).label { "Gender" }
       Field(:gender).radio do |r|
-        div { r.button("m") { "Male" } }
-        div { r.button("f") { "Female" } }
-        div { r.button("o") { "Other" } }
+        div { r.option("m") { "Male" } }
+        div { r.option("f") { "Female" } }
+        div { r.option("o") { "Other" } }
       end
     end
 

--- a/lib/superform/rails/components/checkbox.rb
+++ b/lib/superform/rails/components/checkbox.rb
@@ -8,8 +8,8 @@ module Superform
         end
 
         def view_template(&block)
-          if collection_mode? || block_given?
-            # Collection mode: render multiple checkboxes
+          if array_mode? || block_given?
+            # Array mode: render multiple checkboxes
             if block_given?
               yield self
             else
@@ -25,7 +25,7 @@ module Superform
           end
         end
 
-        # Collection mode methods
+        # Array mode methods
         def options(*option_list)
           map_options(option_list).each do |value, label|
             option(value) { label }
@@ -40,14 +40,14 @@ module Superform
               id: "#{dom.id}_#{value}",
               name: "#{dom.name}[]",
               value: value.to_s,
-              checked: checked_in_collection?(value)
+              checked: checked_in_array?(value)
             )
             plain(yield) if block_given?
           end
         end
 
         protected
-          def collection_mode?
+          def array_mode?
             @options.any?
           end
 
@@ -55,8 +55,8 @@ module Superform
             OptionMapper.new(option_list)
           end
 
-          def checked_in_collection?(value)
-            # Checkbox groups are multi-select, so field.value should be an array
+          def checked_in_array?(value)
+            # Checkbox arrays are multi-select, so field.value should be an array
             field_value = field.value
             return false if field_value.nil?
 
@@ -65,7 +65,7 @@ module Superform
           end
 
           def field_attributes
-            if collection_mode?
+            if array_mode?
               # option method handles all attributes explicitly
               {}
             else

--- a/lib/superform/rails/components/checkbox.rb
+++ b/lib/superform/rails/components/checkbox.rb
@@ -2,18 +2,13 @@ module Superform
   module Rails
     module Components
       class Checkbox < Field
-        def initialize(
-          *,
-          options: [],
-          **,
-          &
-        )
-          super(*, **, &)
-          @options = options
+        def initialize(field, *option_list, **, &)
+          super(field, **, &)
+          @options = option_list
         end
 
         def view_template(&block)
-          if collection_mode?
+          if collection_mode? || block_given?
             # Collection mode: render multiple checkboxes
             if block_given?
               yield self

--- a/lib/superform/rails/components/checkbox.rb
+++ b/lib/superform/rails/components/checkbox.rb
@@ -18,7 +18,7 @@ module Superform
             if block_given?
               yield self
             else
-              buttons(*@options)
+              options(*@options)
             end
           else
             # Boolean mode: single checkbox with hidden field
@@ -31,13 +31,13 @@ module Superform
         end
 
         # Collection mode methods
-        def buttons(*option_list)
+        def options(*option_list)
           map_options(option_list).each do |value, label|
-            button(value) { label }
+            option(value) { label }
           end
         end
 
-        def button(value, &block)
+        def option(value, &block)
           label do
             input(
               **attributes,
@@ -71,7 +71,7 @@ module Superform
 
           def field_attributes
             if collection_mode?
-              # button method handles all attributes explicitly
+              # option method handles all attributes explicitly
               {}
             else
               { id: dom.id, name: dom.name, checked: field.value }

--- a/lib/superform/rails/components/checkbox.rb
+++ b/lib/superform/rails/components/checkbox.rb
@@ -2,17 +2,80 @@ module Superform
   module Rails
     module Components
       class Checkbox < Field
-        def view_template(&)
-          # Rails has a hidden and checkbox input to deal with sending back a value
-          # to the server regardless of if the input is checked or not.
-          input(name: dom.name, type: :hidden, value: "0")
-          # The hard coded keys need to be in here so the user can't overrite them.
-          input(type: :checkbox, value: "1", **attributes)
+        def initialize(
+          *,
+          options: [],
+          **,
+          &
+        )
+          super(*, **, &)
+          @options = options
         end
 
-        def field_attributes
-          { id: dom.id, name: dom.name, checked: field.value }
+        def view_template(&block)
+          if collection_mode?
+            # Collection mode: render multiple checkboxes
+            if block_given?
+              yield self
+            else
+              buttons(*@options)
+            end
+          else
+            # Boolean mode: single checkbox with hidden field
+            # Rails has a hidden and checkbox input to deal with sending back
+            # a value to the server regardless of if the input is checked or not.
+            input(name: dom.name, type: :hidden, value: "0")
+            # The hard coded keys need to be in here so the user can't overrite them.
+            input(type: :checkbox, value: "1", **attributes)
+          end
         end
+
+        # Collection mode methods
+        def buttons(*option_list)
+          map_options(option_list).each do |value, label|
+            button(value) { label }
+          end
+        end
+
+        def button(value, &block)
+          label do
+            input(
+              **attributes,
+              type: :checkbox,
+              id: "#{dom.id}_#{value}",
+              name: "#{dom.name}[]",
+              value: value.to_s,
+              checked: checked_in_collection?(value)
+            )
+            plain(yield) if block_given?
+          end
+        end
+
+        protected
+          def collection_mode?
+            @options.any?
+          end
+
+          def map_options(option_list)
+            OptionMapper.new(option_list)
+          end
+
+          def checked_in_collection?(value)
+            # Checkbox groups are multi-select, so field.value should be an array
+            field_value = field.value
+            return false if field_value.nil?
+
+            field_value = [field_value] unless field_value.is_a?(Array)
+            field_value.map(&:to_s).include?(value.to_s)
+          end
+
+          def field_attributes
+            if collection_mode?
+              { name: "#{dom.name}[]" }
+            else
+              { id: dom.id, name: dom.name, checked: field.value }
+            end
+          end
       end
     end
   end

--- a/lib/superform/rails/components/checkbox.rb
+++ b/lib/superform/rails/components/checkbox.rb
@@ -71,7 +71,8 @@ module Superform
 
           def field_attributes
             if collection_mode?
-              { name: "#{dom.name}[]" }
+              # button method handles all attributes explicitly
+              {}
             else
               { id: dom.id, name: dom.name, checked: field.value }
             end

--- a/lib/superform/rails/components/checkbox.rb
+++ b/lib/superform/rails/components/checkbox.rb
@@ -42,7 +42,10 @@ module Superform
               value: value.to_s,
               checked: checked_in_array?(value)
             )
-            plain(yield) if block_given?
+            if block_given?
+              content = yield
+              content.html_safe? ? raw(content) : plain(content)
+            end
           end
         end
 

--- a/lib/superform/rails/components/label.rb
+++ b/lib/superform/rails/components/label.rb
@@ -8,7 +8,19 @@ module Superform
         end
 
         def field_attributes
-          { for: dom.id }
+          # Only include 'for' attribute if explicitly provided or default
+          # Skip it if set to false/nil to avoid invalid HTML
+          attrs = {}
+          for_value = @attributes&.fetch(:for, :default)
+
+          if for_value == :default
+            attrs[:for] = dom.id
+          elsif for_value
+            attrs[:for] = for_value
+          end
+          # If for_value is false/nil, skip the attribute entirely
+
+          attrs
         end
 
         def label_text

--- a/lib/superform/rails/components/radio.rb
+++ b/lib/superform/rails/components/radio.rb
@@ -2,14 +2,9 @@ module Superform
   module Rails
     module Components
       class Radio < Field
-        def initialize(
-          *,
-          options: [],
-          **,
-          &
-        )
-          super(*, **, &)
-          @options = options
+        def initialize(field, *option_list, **, &)
+          super(field, **, &)
+          @options = option_list
         end
 
         def view_template(&block)

--- a/lib/superform/rails/components/radio.rb
+++ b/lib/superform/rails/components/radio.rb
@@ -20,8 +20,8 @@ module Superform
           end
         end
 
-        def buttons(*collection)
-          map_options(collection).each do |value, label|
+        def buttons(*option_list)
+          map_options(option_list).each do |value, label|
             button(value) { label }
           end
         end
@@ -32,14 +32,19 @@ module Superform
             type: :radio,
             id: "#{dom.id}_#{value}",
             value: value,
-            checked: field.value.to_s == value.to_s
+            checked: checked?(value)
           )
           plain(yield) if block_given?
         end
 
         protected
-          def map_options(collection)
-            OptionMapper.new(collection)
+          def map_options(option_list)
+            OptionMapper.new(option_list)
+          end
+
+          def checked?(value)
+            # Radio buttons are single-select, so field.value should never be an array
+            field.value.to_s == value.to_s
           end
 
           def field_attributes

--- a/lib/superform/rails/components/radio.rb
+++ b/lib/superform/rails/components/radio.rb
@@ -27,14 +27,16 @@ module Superform
         end
 
         def button(value, &block)
-          input(
-            **attributes,
-            type: :radio,
-            id: "#{dom.id}_#{value}",
-            value: value,
-            checked: checked?(value)
-          )
-          plain(yield) if block_given?
+          label do
+            input(
+              **attributes,
+              type: :radio,
+              id: "#{dom.id}_#{value}",
+              value: value.to_s,
+              checked: checked?(value)
+            )
+            plain(yield) if block_given?
+          end
         end
 
         protected

--- a/lib/superform/rails/components/radio.rb
+++ b/lib/superform/rails/components/radio.rb
@@ -1,0 +1,51 @@
+module Superform
+  module Rails
+    module Components
+      class Radio < Field
+        def initialize(
+          *,
+          options: [],
+          **,
+          &
+        )
+          super(*, **, &)
+          @options = options
+        end
+
+        def view_template(&block)
+          if block_given?
+            yield self
+          else
+            buttons(*@options)
+          end
+        end
+
+        def buttons(*collection)
+          map_options(collection).each do |value, label|
+            button(value) { label }
+          end
+        end
+
+        def button(value, &block)
+          input(
+            **attributes,
+            type: :radio,
+            id: "#{dom.id}_#{value}",
+            value: value,
+            checked: field.value.to_s == value.to_s
+          )
+          plain(yield) if block_given?
+        end
+
+        protected
+          def map_options(collection)
+            OptionMapper.new(collection)
+          end
+
+          def field_attributes
+            { name: dom.name }
+          end
+      end
+    end
+  end
+end

--- a/lib/superform/rails/components/radio.rb
+++ b/lib/superform/rails/components/radio.rb
@@ -16,17 +16,17 @@ module Superform
           if block_given?
             yield self
           else
-            buttons(*@options)
+            options(*@options)
           end
         end
 
-        def buttons(*option_list)
+        def options(*option_list)
           map_options(option_list).each do |value, label|
-            button(value) { label }
+            option(value) { label }
           end
         end
 
-        def button(value, &block)
+        def option(value, &block)
           label do
             input(
               **attributes,

--- a/lib/superform/rails/components/radio.rb
+++ b/lib/superform/rails/components/radio.rb
@@ -30,7 +30,10 @@ module Superform
               value: value.to_s,
               checked: checked?(value)
             )
-            plain(yield) if block_given?
+            if block_given?
+              content = yield
+              content.html_safe? ? raw(content) : plain(content)
+            end
           end
         end
 

--- a/lib/superform/rails/field.rb
+++ b/lib/superform/rails/field.rb
@@ -138,19 +138,17 @@ module Superform
       end
 
       def radio(*args, **attributes, &)
-        # If options keyword is provided, create a Radio component for collection
-        if attributes.key?(:options)
-          options = attributes.delete(:options)
-          Components::Radio.new(field, attributes:, options:, &)
-        # If first arg is an array or multiple args provided, treat as collection
-        elsif args.length > 1 || (args.length == 1 && args.first.is_a?(Array))
+        # If multiple args or first arg is an array, treat as collection
+        if args.length > 1 || (args.length == 1 && args.first.is_a?(Array))
           Components::Radio.new(field, attributes:, options: args, &)
-        # Single non-array arg is a radio button value (legacy API)
-        elsif args.length == 1
-          input(type: :radio, value: args.first, **attributes, &)
-        # No args at all - error
+        # If single arg is an ActiveRecord::Relation, treat as collection
+        elsif args.length == 1 && defined?(ActiveRecord::Relation) &&
+              args.first.is_a?(ActiveRecord::Relation)
+          Components::Radio.new(field, attributes:, options: args, &)
+        # No args or single non-collection arg - error
         else
-          raise ArgumentError, "radio requires either a value or options"
+          raise ArgumentError,
+                "radio requires multiple options (e.g., radio(['a', 'A'], ['b', 'B']))"
         end
       end
 

--- a/lib/superform/rails/field.rb
+++ b/lib/superform/rails/field.rb
@@ -137,8 +137,21 @@ module Superform
         input(*, **, type: :file, &)
       end
 
-      def radio(value, *, **, &)
-        input(*, **, type: :radio, value: value, &)
+      def radio(*args, **attributes, &)
+        # If options keyword is provided, create a Radio component for collection
+        if attributes.key?(:options)
+          options = attributes.delete(:options)
+          Components::Radio.new(field, attributes:, options:, &)
+        # If first arg is an array or multiple args provided, treat as collection
+        elsif args.length > 1 || (args.length == 1 && args.first.is_a?(Array))
+          Components::Radio.new(field, attributes:, options: args, &)
+        # Single non-array arg is a radio button value (legacy API)
+        elsif args.length == 1
+          input(type: :radio, value: args.first, **attributes, &)
+        # No args at all - error
+        else
+          raise ArgumentError, "radio requires either a value or options"
+        end
       end
 
       # Rails compatibility aliases

--- a/lib/superform/rails/field.rb
+++ b/lib/superform/rails/field.rb
@@ -139,14 +139,17 @@ module Superform
         input(*, **, type: :file, &)
       end
 
-      def radio(*args, **attributes, &)
+      def radio(*args, **attributes, &block)
         # If multiple args or first arg is an array, treat as collection
         if args.length > 1 || (args.length == 1 && args.first.is_a?(Array))
-          Components::Radio.new(field, attributes:, options: args, &)
+          Components::Radio.new(field, *args, attributes:, &block)
         # If single arg is an ActiveRecord::Relation, treat as collection
         elsif args.length == 1 && defined?(ActiveRecord::Relation) &&
               args.first.is_a?(ActiveRecord::Relation)
-          Components::Radio.new(field, attributes:, options: args, &)
+          Components::Radio.new(field, *args, attributes:, &block)
+        # No args but block given - allow custom rendering
+        elsif args.empty? && block
+          Components::Radio.new(field, attributes:, &block)
         # No args or single non-collection arg - error
         else
           raise ArgumentError,

--- a/lib/superform/rails/field.rb
+++ b/lib/superform/rails/field.rb
@@ -36,7 +36,7 @@ module Superform
       def checkbox(*args, **attributes)
         # Treat as collection if args provided (including single ActiveRecord::Relation)
         # Otherwise treat as boolean checkbox (single true/false)
-        Components::Checkbox.new(field, attributes:, options: args)
+        Components::Checkbox.new(field, *args, attributes:)
       end
 
       def label(**attributes, &)

--- a/lib/superform/rails/field.rb
+++ b/lib/superform/rails/field.rb
@@ -33,8 +33,10 @@ module Superform
         Components::Input.new(field, attributes:)
       end
 
-      def checkbox(**attributes)
-        Components::Checkbox.new(field, attributes:)
+      def checkbox(*args, **attributes)
+        # Treat as collection if args provided (including single ActiveRecord::Relation)
+        # Otherwise treat as boolean checkbox (single true/false)
+        Components::Checkbox.new(field, attributes:, options: args)
       end
 
       def label(**attributes, &)

--- a/spec/superform/rails/components/checkbox_collection_integration_spec.rb
+++ b/spec/superform/rails/components/checkbox_collection_integration_spec.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+RSpec.describe "Checkbox in Collection Integration", type: :view do
+  # Set up test database for collection models
+  before(:all) do
+    ActiveRecord::Schema.define do
+      create_table :pizza_orders, force: true do |t|
+        t.string :toppings
+      end
+    end unless ActiveRecord::Base.connection.table_exists?(:pizza_orders)
+  end
+
+  after(:all) do
+    ActiveRecord::Schema.define do
+      drop_table :pizza_orders if ActiveRecord::Base.connection.table_exists?(:pizza_orders)
+    end
+  end
+
+  # Test model for collection (array of objects)
+  class PizzaOrder < ActiveRecord::Base
+    self.table_name = "pizza_orders"
+    # Serialize toppings as array for multi-select checkboxes
+    serialize :toppings, coder: JSON
+  end
+
+  describe "collection (array of objects with multi-select)" do
+    let(:initial_orders) do
+      [
+        PizzaOrder.new(toppings: ["cheese", "pepperoni"]),
+        PizzaOrder.new(toppings: ["mushrooms"])
+      ]
+    end
+    let(:model) do
+      # Simulates a model with has_many association
+      # Using User with a mock orders association
+      orders_list = initial_orders # capture for closure
+      User.new(first_name: "Test", email: "test@example.com").tap do |user|
+        user.define_singleton_method(:orders) { @orders ||= orders_list }
+        user.define_singleton_method(:orders=) { |val| @orders = val }
+      end
+    end
+    let(:form) { Superform::Rails::Form.new(model, action: "/users") }
+    let(:topping_options) do
+      [
+        ["cheese", "Cheese"],
+        ["pepperoni", "Pepperoni"],
+        ["mushrooms", "Mushrooms"],
+        ["olives", "Olives"]
+      ]
+    end
+
+    it "renders checkboxes with collection notation" do
+      html = render(form) do |f|
+        orders_collection = f.collection(:orders)
+        orders_collection.each do |order_namespace|
+          f.render order_namespace.field(:toppings).checkbox(*topping_options)
+        end
+      end
+
+      # Collection uses model_name[collection_name][index][field_name][] notation
+      # The final [] is for checkbox array submission
+      expect(html).to include('name="user[orders][0][toppings][]"')
+      expect(html).to include('name="user[orders][1][toppings][]"')
+      expect(html.scan(/type="checkbox"/).count).to eq(8) # 4 checkboxes × 2 orders
+    end
+
+    it "pre-selects checkboxes based on collection values" do
+      html = render(form) do |f|
+        orders_collection = f.collection(:orders)
+        orders_collection.each do |order_namespace|
+          f.render order_namespace.field(:toppings).checkbox(*topping_options)
+        end
+      end
+
+      # Should have exactly 3 checked checkboxes total
+      # First order: cheese, pepperoni (2 checked)
+      # Second order: mushrooms (1 checked)
+      expect(html.scan(/checked/).count).to eq(3)
+
+      # "cheese" should be checked (first order)
+      expect(html).to match(/<input[^>]*id="user_orders_0_toppings_cheese"[^>]*checked/)
+      # "pepperoni" should be checked (first order)
+      expect(html).to match(/<input[^>]*id="user_orders_0_toppings_pepperoni"[^>]*checked/)
+      # "mushrooms" should be checked (second order)
+      expect(html).to match(/<input[^>]*id="user_orders_1_toppings_mushrooms"[^>]*checked/)
+    end
+
+    it "does not check unselected options" do
+      html = render(form) do |f|
+        orders_collection = f.collection(:orders)
+        orders_collection.each do |order_namespace|
+          f.render order_namespace.field(:toppings).checkbox(*topping_options)
+        end
+      end
+
+      # "olives" should not be checked in either order
+      expect(html).not_to match(/<input[^>]*id="user_orders_0_toppings_olives"[^>]*checked/)
+      expect(html).not_to match(/<input[^>]*id="user_orders_1_toppings_olives"[^>]*checked/)
+
+      # "mushrooms" should not be checked in first order
+      expect(html).not_to match(/<input[^>]*id="user_orders_0_toppings_mushrooms"[^>]*checked/)
+    end
+
+    it "works with submitted params from collection" do
+      # Simulate Rails params after form submission
+      # Collection checkboxes submit as:
+      # { "user" => { "orders" => [
+      #   { "toppings" => ["olives", "mushrooms"] },
+      #   { "toppings" => ["cheese", "pepperoni", "olives"] }
+      # ] } }
+      submitted_model = User.new(first_name: "Test", email: "test@example.com").tap do |user|
+        user.define_singleton_method(:orders) do
+          [
+            PizzaOrder.new(toppings: ["olives", "mushrooms"]),
+            PizzaOrder.new(toppings: ["cheese", "pepperoni", "olives"])
+          ]
+        end
+      end
+      submitted_form = Superform::Rails::Form.new(submitted_model, action: "/users")
+
+      html = render(submitted_form) do |f|
+        orders_collection = f.collection(:orders)
+        orders_collection.each do |order_namespace|
+          f.render order_namespace.field(:toppings).checkbox(*topping_options)
+        end
+      end
+
+      # Should have exactly 5 checked checkboxes
+      # First order: olives, mushrooms (2 checked)
+      # Second order: cheese, pepperoni, olives (3 checked)
+      expect(html.scan(/checked/).count).to eq(5)
+
+      # First order should have "olives" and "mushrooms" checked
+      expect(html).to match(/<input[^>]*id="user_orders_0_toppings_olives"[^>]*checked/)
+      expect(html).to match(/<input[^>]*id="user_orders_0_toppings_mushrooms"[^>]*checked/)
+
+      # Second order should have "cheese", "pepperoni", "olives" checked
+      expect(html).to match(/<input[^>]*id="user_orders_1_toppings_cheese"[^>]*checked/)
+      expect(html).to match(/<input[^>]*id="user_orders_1_toppings_pepperoni"[^>]*checked/)
+      expect(html).to match(/<input[^>]*id="user_orders_1_toppings_olives"[^>]*checked/)
+    end
+
+    it "wraps each checkbox in a label for clickability" do
+      html = render(form) do |f|
+        orders_collection = f.collection(:orders)
+        orders_collection.each do |order_namespace|
+          f.render order_namespace.field(:toppings).checkbox(*topping_options)
+        end
+      end
+
+      # Each checkbox should be wrapped in a label
+      # 4 options × 2 orders = 8 labels
+      expect(html.scan(/<label>/).count).to eq(8)
+      expect(html.scan(/<\/label>/).count).to eq(8)
+    end
+  end
+
+  describe "boolean checkboxes in collection" do
+    before(:all) do
+      ActiveRecord::Schema.define do
+        create_table :tasks, force: true do |t|
+          t.boolean :completed
+        end
+      end unless ActiveRecord::Base.connection.table_exists?(:tasks)
+    end
+
+    after(:all) do
+      ActiveRecord::Schema.define do
+        drop_table :tasks if ActiveRecord::Base.connection.table_exists?(:tasks)
+      end
+    end
+
+    class Task < ActiveRecord::Base
+    end
+
+    let(:initial_tasks) do
+      [
+        Task.new(completed: true),
+        Task.new(completed: false)
+      ]
+    end
+    let(:model) do
+      tasks_list = initial_tasks
+      User.new(first_name: "Test", email: "test@example.com").tap do |user|
+        user.define_singleton_method(:tasks) { @tasks ||= tasks_list }
+        user.define_singleton_method(:tasks=) { |val| @tasks = val }
+      end
+    end
+    let(:form) { Superform::Rails::Form.new(model, action: "/users") }
+
+    it "renders boolean checkboxes with hidden fields in collection" do
+      html = render(form) do |f|
+        tasks_collection = f.collection(:tasks)
+        tasks_collection.each do |task_namespace|
+          f.render task_namespace.field(:completed).checkbox
+        end
+      end
+
+      # Should have hidden fields for each checkbox (value="0")
+      # Plus form authenticity_token and _method fields
+      expect(html.scan(/type="hidden"[^>]*value="0"/).count).to eq(2)
+      # Each task should have both hidden and checkbox inputs with same name
+      expect(html.scan(/name="user\[tasks\]\[0\]\[completed\]"/).count).to eq(2) # hidden + checkbox
+      expect(html.scan(/name="user\[tasks\]\[1\]\[completed\]"/).count).to eq(2) # hidden + checkbox
+    end
+
+    it "checks boolean checkboxes based on true/false values" do
+      html = render(form) do |f|
+        tasks_collection = f.collection(:tasks)
+        tasks_collection.each do |task_namespace|
+          f.render task_namespace.field(:completed).checkbox
+        end
+      end
+
+      # First task is completed (true) - should be checked
+      expect(html).to match(/<input[^>]*id="user_tasks_0_completed"[^>]*checked/)
+
+      # Second task is not completed (false) - should not be checked
+      expect(html).not_to match(/<input[^>]*id="user_tasks_1_completed"[^>]*checked/)
+    end
+  end
+end

--- a/spec/superform/rails/components/checkbox_spec.rb
+++ b/spec/superform/rails/components/checkbox_spec.rb
@@ -293,8 +293,8 @@ RSpec.describe Superform::Rails::Components::Checkbox, type: :view do
 
     subject do
       render(component) do |checkbox|
-        checkbox.button('shirako') { 'Shirako' }
-        checkbox.button('ankimo') { 'Ankimo' }
+        checkbox.option('shirako') { 'Shirako' }
+        checkbox.option('ankimo') { 'Ankimo' }
       end
     end
 

--- a/spec/superform/rails/components/checkbox_spec.rb
+++ b/spec/superform/rails/components/checkbox_spec.rb
@@ -1,0 +1,378 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/BlockLength
+RSpec.describe Superform::Rails::Components::Checkbox, type: :view do
+  describe 'boolean mode (backwards compatibility)' do
+    let(:object) { double('object', featured: featured_value) }
+    let(:featured_value) { false }
+    let(:field) do
+      Superform::Rails::Field.new(:featured, parent: nil, object: object)
+    end
+    let(:component) do
+      described_class.new(field, attributes: attributes)
+    end
+    let(:attributes) { {} }
+
+    subject { render(component) }
+
+    it 'renders a hidden input with value 0' do
+      expect(subject).to include('type="hidden"')
+      expect(subject).to include('value="0"')
+    end
+
+    it 'renders a checkbox input with value 1' do
+      expect(subject).to include('type="checkbox"')
+      expect(subject).to include('value="1"')
+    end
+
+    it 'uses the correct name for both inputs' do
+      expect(subject.scan(/name="featured"/).count).to eq(2)
+    end
+
+    it 'does not wrap inputs in a label' do
+      expect(subject).not_to include('<label>')
+    end
+
+    it 'renders both inputs without wrapper' do
+      expect(subject).to eq(
+        '<input name="featured" type="hidden" value="0">' \
+        '<input type="checkbox" value="1" id="featured" name="featured">'
+      )
+    end
+
+    context 'when value is false' do
+      let(:featured_value) { false }
+
+      it 'does not check the checkbox' do
+        expect(subject).not_to include('checked')
+      end
+    end
+
+    context 'when value is true' do
+      let(:featured_value) { true }
+
+      it 'checks the checkbox' do
+        expect(subject).to match(/<input[^>]*type="checkbox"[^>]*checked/)
+      end
+    end
+  end
+
+  describe 'collection mode (multi-select)' do
+    let(:object) { double('object', sushi: sushi_value) }
+    let(:sushi_value) { [] }
+    let(:field) do
+      Superform::Rails::Field.new(:sushi, parent: nil, object: object)
+    end
+    let(:options) do
+      [
+        ['shirako', 'Shirako'],
+        ['ankimo', 'Ankimo'],
+        ['tsubugai', 'Tsubugai']
+      ]
+    end
+    let(:component) do
+      described_class.new(field, attributes: attributes, options: options)
+    end
+    let(:attributes) { {} }
+
+    subject { render(component) }
+
+    it 'renders multiple checkbox inputs' do
+      expect(subject.scan(/<input[^>]*type="checkbox"/).count).to eq(3)
+    end
+
+    it 'does not render hidden inputs in collection mode' do
+      expect(subject).not_to include('type="hidden"')
+    end
+
+    it 'renders checkboxes with correct values' do
+      expect(subject).to include('value="shirako"')
+      expect(subject).to include('value="ankimo"')
+      expect(subject).to include('value="tsubugai"')
+    end
+
+    it 'renders unique IDs for each checkbox' do
+      expect(subject).to include('id="sushi_shirako"')
+      expect(subject).to include('id="sushi_ankimo"')
+      expect(subject).to include('id="sushi_tsubugai"')
+    end
+
+    it 'uses array notation for all checkbox names' do
+      expect(subject.scan(/name="sushi\[\]"/).count).to eq(3)
+    end
+
+    it 'wraps each checkbox in a label' do
+      expect(subject.scan(/<label>/).count).to eq(3)
+      expect(subject.scan(/<\/label>/).count).to eq(3)
+    end
+
+    it 'does not check any checkbox by default' do
+      expect(subject).not_to include('checked')
+    end
+
+    it 'renders complete HTML structure' do
+      expect(subject).to eq(
+        '<label><input name="sushi[]" type="checkbox" id="sushi_shirako" value="shirako">Shirako</label>' \
+        '<label><input name="sushi[]" type="checkbox" id="sushi_ankimo" value="ankimo">Ankimo</label>' \
+        '<label><input name="sushi[]" type="checkbox" id="sushi_tsubugai" value="tsubugai">Tsubugai</label>'
+      )
+    end
+
+    context 'with selected values' do
+      let(:sushi_value) { ['ankimo', 'tsubugai'] }
+
+      it 'checks the matching checkboxes' do
+        expect(subject).to match(
+          /<input[^>]*id="sushi_ankimo"[^>]*checked[^>]*>/
+        )
+        expect(subject).to match(
+          /<input[^>]*id="sushi_tsubugai"[^>]*checked[^>]*>/
+        )
+      end
+
+      it 'does not check other checkboxes' do
+        expect(subject).not_to match(
+          /<input[^>]*id="sushi_shirako"[^>]*checked[^>]*>/
+        )
+      end
+
+      it 'renders complete HTML structure with checked state' do
+        expect(subject).to eq(
+          '<label><input name="sushi[]" type="checkbox" id="sushi_shirako" value="shirako">Shirako</label>' \
+          '<label><input name="sushi[]" type="checkbox" id="sushi_ankimo" value="ankimo" checked>Ankimo</label>' \
+          '<label><input name="sushi[]" type="checkbox" id="sushi_tsubugai" value="tsubugai" checked>Tsubugai</label>'
+        )
+      end
+    end
+
+    context 'with numeric values' do
+      let(:object) { double('object', role_ids: role_ids_value) }
+      let(:role_ids_value) { [2, 3] }
+      let(:field) do
+        Superform::Rails::Field.new(:role_ids, parent: nil, object: object)
+      end
+      let(:options) { [[1, 'Admin'], [2, 'Editor'], [3, 'Viewer']] }
+
+      it 'checks the matching checkboxes with numeric comparison' do
+        expect(subject).to match(
+          /<input[^>]*id="role_ids_2"[^>]*checked[^>]*>/
+        )
+        expect(subject).to match(
+          /<input[^>]*id="role_ids_3"[^>]*checked[^>]*>/
+        )
+      end
+    end
+  end
+
+  describe 'using field helper method' do
+    let(:form_field) do
+      Superform::Rails::Field.new(:sushi, parent: nil, object: object)
+    end
+    let(:object) { double('object', sushi: []) }
+
+    context 'with positional arguments (collection mode)' do
+      subject do
+        render(
+          form_field.checkbox(
+            ['shirako', 'Shirako'],
+            ['ankimo', 'Ankimo'],
+            ['tsubugai', 'Tsubugai']
+          )
+        )
+      end
+
+      it 'renders checkboxes from positional args' do
+        expect(subject).to include('value="shirako"')
+        expect(subject).to include('value="ankimo"')
+        expect(subject).to include('value="tsubugai"')
+      end
+
+      it 'uses array notation for names' do
+        expect(subject.scan(/name="sushi\[\]"/).count).to eq(3)
+      end
+    end
+
+    context 'with mixed format positional arguments' do
+      let(:object) { double('object', preferences: []) }
+      let(:form_field) do
+        Superform::Rails::Field.new(:preferences, parent: nil, object: object)
+      end
+
+      subject do
+        render(
+          form_field.checkbox(
+            [true, 'Email notifications'],
+            [false, 'SMS notifications'],
+            'Push notifications'
+          )
+        )
+      end
+
+      it 'renders checkboxes with array pairs using first as value' do
+        expect(subject).to include('value="true"')
+        expect(subject).to include('value="false"')
+      end
+
+      it 'renders checkboxes with array pairs using second as label' do
+        expect(subject).to include('>Email notifications')
+        expect(subject).to include('>SMS notifications')
+      end
+
+      it 'renders checkbox with single value for both value and label' do
+        expect(subject).to include('value="Push notifications"')
+        expect(subject).to include('>Push notifications')
+      end
+    end
+
+    context 'without arguments (boolean mode)' do
+      let(:object) { double('object', featured: false) }
+      let(:form_field) do
+        Superform::Rails::Field.new(:featured, parent: nil, object: object)
+      end
+
+      subject do
+        render(form_field.checkbox)
+      end
+
+      it 'renders a boolean checkbox' do
+        expect(subject).to include('type="checkbox"')
+        expect(subject).to include('value="1"')
+      end
+
+      it 'renders a hidden field' do
+        expect(subject).to include('type="hidden"')
+        expect(subject).to include('value="0"')
+      end
+
+      it 'does not use array notation' do
+        expect(subject).not_to include('name="featured[]"')
+        expect(subject).to include('name="featured"')
+      end
+    end
+  end
+
+  describe 'with custom attributes' do
+    let(:object) { double('object', sushi: []) }
+    let(:field) do
+      Superform::Rails::Field.new(:sushi, parent: nil, object: object)
+    end
+    let(:attributes) { { class: 'custom-checkbox', data: { controller: 'checkbox' } } }
+    let(:component) do
+      described_class.new(
+        field,
+        attributes: attributes,
+        options: [['shirako', 'Shirako'], ['ankimo', 'Ankimo']]
+      )
+    end
+
+    subject { render(component) }
+
+    it 'applies custom attributes to all checkboxes' do
+      expect(subject).to include('class="custom-checkbox"')
+      expect(subject).to include('data-controller="checkbox"')
+      expect(subject.scan(/class="custom-checkbox"/).count).to eq(2)
+    end
+  end
+
+  describe 'with block for custom rendering' do
+    let(:object) { double('object', sushi: []) }
+    let(:field) do
+      Superform::Rails::Field.new(:sushi, parent: nil, object: object)
+    end
+    let(:component) do
+      described_class.new(
+        field,
+        attributes: {},
+        options: [
+          ['shirako', 'Shirako'],
+          ['ankimo', 'Ankimo'],
+          ['tsubugai', 'Tsubugai']
+        ]
+      )
+    end
+
+    subject do
+      render(component) do |checkbox|
+        checkbox.button('shirako') { 'Shirako' }
+        checkbox.button('ankimo') { 'Ankimo' }
+      end
+    end
+
+    it 'renders custom checkboxes via block' do
+      expect(subject).to include('value="shirako"')
+      expect(subject).to include('value="ankimo"')
+    end
+
+    it 'does not render options from constructor' do
+      expect(subject).not_to include('value="tsubugai"')
+    end
+  end
+
+  describe 'with ActiveRecord::Relation' do
+    before do
+      User.create!(first_name: 'Alice', email: 'alice@example.com')
+      User.create!(first_name: 'Bob', email: 'bob@example.com')
+      User.create!(first_name: 'Charlie', email: 'charlie@example.com')
+    end
+
+    after do
+      User.delete_all
+    end
+
+    let(:object) { double('object', author_ids: author_ids_value) }
+    let(:author_ids_value) { [] }
+    let(:field) do
+      Superform::Rails::Field.new(:author_ids, parent: nil, object: object)
+    end
+    let(:users_relation) { User.select(:id, :first_name) }
+
+    context 'passed directly via field helper' do
+      let(:form_field) do
+        Superform::Rails::Field.new(:author_ids, parent: nil, object: object)
+      end
+
+      subject do
+        # Pass relation directly without wrapping in array
+        render(form_field.checkbox(users_relation))
+      end
+
+      it 'renders checkboxes from ActiveRecord relation' do
+        expect(subject).to match(/<input[^>]*value="\d+"[^>]*>Alice/)
+        expect(subject).to match(/<input[^>]*value="\d+"[^>]*>Bob/)
+        expect(subject).to match(/<input[^>]*value="\d+"[^>]*>Charlie/)
+      end
+
+      it 'uses array notation for names' do
+        expect(subject.scan(/name="author_ids\[\]"/).count).to eq(3)
+      end
+
+      it 'generates proper HTML structure with labels' do
+        expect(subject).to include('<label>')
+        expect(subject.scan(/<label>/).count).to eq(3)
+      end
+
+      context 'with selected values' do
+        let(:alice) { User.find_by(first_name: 'Alice') }
+        let(:charlie) { User.find_by(first_name: 'Charlie') }
+        let(:author_ids_value) { [alice.id, charlie.id] }
+
+        it 'checks the matching checkboxes' do
+          expect(subject).to match(
+            /<input[^>]*id="author_ids_#{alice.id}"[^>]*checked[^>]*>/
+          )
+          expect(subject).to match(
+            /<input[^>]*id="author_ids_#{charlie.id}"[^>]*checked[^>]*>/
+          )
+        end
+
+        it 'does not check other checkboxes' do
+          bob = User.find_by(first_name: 'Bob')
+          expect(subject).not_to match(
+            /<input[^>]*id="author_ids_#{bob.id}"[^>]*checked[^>]*>/
+          )
+        end
+      end
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/spec/superform/rails/components/checkbox_spec.rb
+++ b/spec/superform/rails/components/checkbox_spec.rb
@@ -112,9 +112,9 @@ RSpec.describe Superform::Rails::Components::Checkbox, type: :view do
 
     it 'renders complete HTML structure' do
       expect(subject).to eq(
-        '<label><input name="sushi[]" type="checkbox" id="sushi_shirako" value="shirako">Shirako</label>' \
-        '<label><input name="sushi[]" type="checkbox" id="sushi_ankimo" value="ankimo">Ankimo</label>' \
-        '<label><input name="sushi[]" type="checkbox" id="sushi_tsubugai" value="tsubugai">Tsubugai</label>'
+        '<label><input type="checkbox" id="sushi_shirako" name="sushi[]" value="shirako">Shirako</label>' \
+        '<label><input type="checkbox" id="sushi_ankimo" name="sushi[]" value="ankimo">Ankimo</label>' \
+        '<label><input type="checkbox" id="sushi_tsubugai" name="sushi[]" value="tsubugai">Tsubugai</label>'
       )
     end
 
@@ -138,9 +138,9 @@ RSpec.describe Superform::Rails::Components::Checkbox, type: :view do
 
       it 'renders complete HTML structure with checked state' do
         expect(subject).to eq(
-          '<label><input name="sushi[]" type="checkbox" id="sushi_shirako" value="shirako">Shirako</label>' \
-          '<label><input name="sushi[]" type="checkbox" id="sushi_ankimo" value="ankimo" checked>Ankimo</label>' \
-          '<label><input name="sushi[]" type="checkbox" id="sushi_tsubugai" value="tsubugai" checked>Tsubugai</label>'
+          '<label><input type="checkbox" id="sushi_shirako" name="sushi[]" value="shirako">Shirako</label>' \
+          '<label><input type="checkbox" id="sushi_ankimo" name="sushi[]" value="ankimo" checked>Ankimo</label>' \
+          '<label><input type="checkbox" id="sushi_tsubugai" name="sushi[]" value="tsubugai" checked>Tsubugai</label>'
         )
       end
     end

--- a/spec/superform/rails/components/checkbox_spec.rb
+++ b/spec/superform/rails/components/checkbox_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Superform::Rails::Components::Checkbox, type: :view do
     end
   end
 
-  describe 'collection mode (multi-select)' do
+  describe 'array mode (multi-select)' do
     let(:object) { double('object', sushi: sushi_value) }
     let(:sushi_value) { [] }
     let(:field) do
@@ -81,7 +81,7 @@ RSpec.describe Superform::Rails::Components::Checkbox, type: :view do
       expect(subject.scan(/<input[^>]*type="checkbox"/).count).to eq(3)
     end
 
-    it 'does not render hidden inputs in collection mode' do
+    it 'does not render hidden inputs in array mode' do
       expect(subject).not_to include('type="hidden"')
     end
 
@@ -170,7 +170,7 @@ RSpec.describe Superform::Rails::Components::Checkbox, type: :view do
     end
     let(:object) { double('object', sushi: []) }
 
-    context 'with positional arguments (collection mode)' do
+    context 'with positional arguments (array mode)' do
       subject do
         render(
           form_field.checkbox(

--- a/spec/superform/rails/components/checkbox_spec.rb
+++ b/spec/superform/rails/components/checkbox_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Superform::Rails::Components::Checkbox, type: :view do
       ]
     end
     let(:component) do
-      described_class.new(field, attributes: attributes, options: options)
+      described_class.new(field, *options, attributes: attributes)
     end
     let(:attributes) { {} }
 
@@ -260,8 +260,9 @@ RSpec.describe Superform::Rails::Components::Checkbox, type: :view do
     let(:component) do
       described_class.new(
         field,
-        attributes: attributes,
-        options: [['shirako', 'Shirako'], ['ankimo', 'Ankimo']]
+        ['shirako', 'Shirako'],
+        ['ankimo', 'Ankimo'],
+        attributes: attributes
       )
     end
 
@@ -282,12 +283,10 @@ RSpec.describe Superform::Rails::Components::Checkbox, type: :view do
     let(:component) do
       described_class.new(
         field,
-        attributes: {},
-        options: [
-          ['shirako', 'Shirako'],
-          ['ankimo', 'Ankimo'],
-          ['tsubugai', 'Tsubugai']
-        ]
+        ['shirako', 'Shirako'],
+        ['ankimo', 'Ankimo'],
+        ['tsubugai', 'Tsubugai'],
+        attributes: {}
       )
     end
 
@@ -305,6 +304,36 @@ RSpec.describe Superform::Rails::Components::Checkbox, type: :view do
 
     it 'does not render options from constructor' do
       expect(subject).not_to include('value="tsubugai"')
+    end
+  end
+
+  describe 'with block but no constructor options' do
+    let(:object) { double('object', features: []) }
+    let(:field) do
+      Superform::Rails::Field.new(:features, parent: nil, object: object)
+    end
+    let(:component) do
+      described_class.new(field, attributes: {})
+    end
+
+    subject do
+      render(component) do |checkbox|
+        checkbox.option('dark_mode') { 'Dark Mode' }
+        checkbox.option('notifications') { 'Notifications' }
+      end
+    end
+
+    it 'renders checkboxes from block without constructor options' do
+      expect(subject).to include('value="dark_mode"')
+      expect(subject).to include('value="notifications"')
+    end
+
+    it 'wraps each checkbox in a label' do
+      expect(subject.scan(/<label>/).count).to eq(2)
+    end
+
+    it 'uses array notation for names' do
+      expect(subject.scan(/name="features\[\]"/).count).to eq(2)
     end
   end
 

--- a/spec/superform/rails/components/label_spec.rb
+++ b/spec/superform/rails/components/label_spec.rb
@@ -6,11 +6,42 @@ RSpec.describe Superform::Rails::Components::Label do
   let(:user) { User.new(first_name: "John") }
   let(:form) { Superform::Rails::Form.new(user) }
   let(:field) { form.field(:first_name) }
-  let(:label) { described_class.new(field, attributes: { class: "form-label" }) }
+  let(:label) { described_class.new(field, attributes: attributes) }
+  let(:attributes) { { class: "form-label" } }
 
   subject { label.call }
 
   it "renders label with titleized field name" do
     expect(subject).to eq('<label for="user_first_name" class="form-label">First name</label>')
+  end
+
+  context "with for: false" do
+    let(:attributes) { { class: "form-label", for: false } }
+
+    it "renders label without for attribute" do
+      expect(subject).to eq('<label class="form-label">First name</label>')
+    end
+
+    it "does not include for attribute" do
+      expect(subject).not_to include('for=')
+    end
+  end
+
+  context "with for: nil" do
+    let(:attributes) { { class: "form-label", for: nil } }
+
+    it "renders label without for attribute" do
+      expect(subject).to eq('<label class="form-label">First name</label>')
+    end
+  end
+
+  context "with custom for value" do
+    let(:attributes) { { class: "form-label", for: "custom_id" } }
+
+    it "renders label with custom for attribute" do
+      expect(subject).to include('for="custom_id"')
+      expect(subject).to include('class="form-label"')
+      expect(subject).to include('>First name</label>')
+    end
   end
 end

--- a/spec/superform/rails/components/radio_collection_integration_spec.rb
+++ b/spec/superform/rails/components/radio_collection_integration_spec.rb
@@ -47,11 +47,9 @@ RSpec.describe "Radio in Collection Integration", type: :view do
         orders_collection = f.collection(:orders)
         orders_collection.each do |order_namespace|
           f.render order_namespace.field(:sushi).radio(
-            options: [
-              ["shirako", "Shirako"],
-              ["ankimo", "Ankimo"],
-              ["tsubugai", "Tsubugai"]
-            ]
+            ["shirako", "Shirako"],
+            ["ankimo", "Ankimo"],
+            ["tsubugai", "Tsubugai"]
           )
         end
       end
@@ -68,11 +66,9 @@ RSpec.describe "Radio in Collection Integration", type: :view do
         orders_collection = f.collection(:orders)
         orders_collection.each do |order_namespace|
           f.render order_namespace.field(:sushi).radio(
-            options: [
-              ["shirako", "Shirako"],
-              ["ankimo", "Ankimo"],
-              ["tsubugai", "Tsubugai"]
-            ]
+            ["shirako", "Shirako"],
+            ["ankimo", "Ankimo"],
+            ["tsubugai", "Tsubugai"]
           )
         end
       end
@@ -102,11 +98,9 @@ RSpec.describe "Radio in Collection Integration", type: :view do
         orders_collection = f.collection(:orders)
         orders_collection.each do |order_namespace|
           f.render order_namespace.field(:sushi).radio(
-            options: [
-              ["shirako", "Shirako"],
-              ["ankimo", "Ankimo"],
-              ["tsubugai", "Tsubugai"]
-            ]
+            ["shirako", "Shirako"],
+            ["ankimo", "Ankimo"],
+            ["tsubugai", "Tsubugai"]
           )
         end
       end

--- a/spec/superform/rails/components/radio_collection_integration_spec.rb
+++ b/spec/superform/rails/components/radio_collection_integration_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+RSpec.describe "Radio in Collection Integration", type: :view do
+  # Set up test database for collection models
+  before(:all) do
+    ActiveRecord::Schema.define do
+      create_table :orders, force: true do |t|
+        t.string :sushi
+      end
+    end unless ActiveRecord::Base.connection.table_exists?(:orders)
+  end
+
+  after(:all) do
+    ActiveRecord::Schema.define do
+      drop_table :orders if ActiveRecord::Base.connection.table_exists?(:orders)
+    end
+  end
+
+  # Test model for collection (array of objects)
+  class Order < ActiveRecord::Base
+  end
+
+  # Note: Field collections (arrays of primitives) don't make sense for radio buttons
+  # since radios are for single-select, not multiple array elements.
+  # For multi-select from primitives, use checkboxes instead.
+
+  describe "collection (array of objects)" do
+    let(:initial_orders) do
+      [
+        Order.new(sushi: "shirako"),
+        Order.new(sushi: "ankimo")
+      ]
+    end
+    let(:model) do
+      # Simulates a model with has_many association
+      # Using User with a mock orders association
+      orders_list = initial_orders # capture for closure
+      User.new(first_name: "Test", email: "test@example.com").tap do |user|
+        user.define_singleton_method(:orders) { @orders ||= orders_list }
+        user.define_singleton_method(:orders=) { |val| @orders = val }
+      end
+    end
+    let(:form) { Superform::Rails::Form.new(model, action: "/users") }
+
+    it "renders radio buttons with collection notation" do
+      html = render(form) do |f|
+        orders_collection = f.collection(:orders)
+        orders_collection.each do |order_namespace|
+          f.render order_namespace.field(:sushi).radio(
+            options: [
+              ["shirako", "Shirako"],
+              ["ankimo", "Ankimo"],
+              ["tsubugai", "Tsubugai"]
+            ]
+          )
+        end
+      end
+
+      # Collection uses model_name[collection_name][index][field_name] notation
+      # Rails will parse { "0" => {}, "1" => {} } into an array
+      expect(html).to include('name="user[orders][0][sushi]"')
+      expect(html).to include('name="user[orders][1][sushi]"')
+      expect(html.scan(/type="radio"/).count).to eq(6) # 3 radios × 2 orders
+    end
+
+    it "pre-selects radio buttons based on collection values" do
+      html = render(form) do |f|
+        orders_collection = f.collection(:orders)
+        orders_collection.each do |order_namespace|
+          f.render order_namespace.field(:sushi).radio(
+            options: [
+              ["shirako", "Shirako"],
+              ["ankimo", "Ankimo"],
+              ["tsubugai", "Tsubugai"]
+            ]
+          )
+        end
+      end
+
+      # Should have exactly 2 checked radios (one per order)
+      expect(html.scan(/checked/).count).to eq(2)
+      # "shirako" should be checked (first order)
+      expect(html).to match(/<input[^>]*id="user_orders_0_sushi_shirako"[^>]*checked/)
+      # "ankimo" should be checked (second order)
+      expect(html).to match(/<input[^>]*id="user_orders_1_sushi_ankimo"[^>]*checked/)
+    end
+
+    it "works with submitted params from collection" do
+      # Simulate Rails params after form submission
+      # Collection radios submit as: { "user" => { "orders" => [{ "sushi" => "tsubugai" }, { "sushi" => "shirako" }] } }
+      submitted_model = User.new(first_name: "Test", email: "test@example.com").tap do |user|
+        user.define_singleton_method(:orders) do
+          [
+            Order.new(sushi: "tsubugai"),
+            Order.new(sushi: "shirako")
+          ]
+        end
+      end
+      submitted_form = Superform::Rails::Form.new(submitted_model, action: "/users")
+
+      html = render(submitted_form) do |f|
+        orders_collection = f.collection(:orders)
+        orders_collection.each do |order_namespace|
+          f.render order_namespace.field(:sushi).radio(
+            options: [
+              ["shirako", "Shirako"],
+              ["ankimo", "Ankimo"],
+              ["tsubugai", "Tsubugai"]
+            ]
+          )
+        end
+      end
+
+      # Should have exactly 2 checked radios
+      expect(html.scan(/checked/).count).to eq(2)
+      # First order should now have "tsubugai" checked
+      expect(html).to match(/<input[^>]*id="user_orders_0_sushi_tsubugai"[^>]*checked/)
+      # Second order should now have "shirako" checked
+      expect(html).to match(/<input[^>]*id="user_orders_1_sushi_shirako"[^>]*checked/)
+    end
+  end
+end

--- a/spec/superform/rails/components/radio_spec.rb
+++ b/spec/superform/rails/components/radio_spec.rb
@@ -1,0 +1,302 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/BlockLength
+RSpec.describe Superform::Rails::Components::Radio, type: :view do
+  let(:object) { double('object', sushi: sushi_value) }
+  let(:sushi_value) { nil }
+  let(:field) do
+    Superform::Rails::Field.new(:sushi, parent: nil, object: object)
+  end
+  let(:options) do
+    [
+      ['shirako', 'Shirako'],
+      ['ankimo', 'Ankimo'],
+      ['tsubugai', 'Tsubugai']
+    ]
+  end
+  let(:component) do
+    described_class.new(field, attributes: attributes, options: options)
+  end
+  let(:attributes) { {} }
+
+  describe 'basic radio collection' do
+    subject { render(component) }
+
+    it 'renders multiple radio inputs' do
+      expect(subject.scan(/<input[^>]*type="radio"/).count).to eq(3)
+    end
+
+    it 'renders radio inputs with correct values' do
+      expect(subject).to include('value="shirako"')
+      expect(subject).to include('value="ankimo"')
+      expect(subject).to include('value="tsubugai"')
+    end
+
+    it 'renders unique IDs for each radio button' do
+      expect(subject).to include('id="sushi_shirako"')
+      expect(subject).to include('id="sushi_ankimo"')
+      expect(subject).to include('id="sushi_tsubugai"')
+    end
+
+    it 'uses the same name for all radio buttons' do
+      expect(subject.scan(/name="sushi"/).count).to eq(3)
+    end
+
+    it 'does not check any radio by default' do
+      expect(subject).not_to include('checked')
+    end
+
+    it 'renders complete HTML structure' do
+      expect(subject).to eq(
+        '<input name="sushi" type="radio" id="sushi_shirako" value="shirako">Shirako' \
+        '<input name="sushi" type="radio" id="sushi_ankimo" value="ankimo">Ankimo' \
+        '<input name="sushi" type="radio" id="sushi_tsubugai" value="tsubugai">Tsubugai'
+      )
+    end
+  end
+
+  describe 'with selected value' do
+    let(:sushi_value) { 'ankimo' }
+
+    subject { render(component) }
+
+    it 'checks the matching radio button' do
+      expect(subject).to match(
+        /<input[^>]*id="sushi_ankimo"[^>]*checked[^>]*>/
+      )
+    end
+
+    it 'does not check other radio buttons' do
+      expect(subject).not_to match(
+        /<input[^>]*id="sushi_shirako"[^>]*checked[^>]*>/
+      )
+      expect(subject).not_to match(
+        /<input[^>]*id="sushi_tsubugai"[^>]*checked[^>]*>/
+      )
+    end
+
+    it 'renders complete HTML structure with checked state' do
+      expect(subject).to eq(
+        '<input name="sushi" type="radio" id="sushi_shirako" value="shirako">Shirako' \
+        '<input name="sushi" type="radio" id="sushi_ankimo" value="ankimo" checked>Ankimo' \
+        '<input name="sushi" type="radio" id="sushi_tsubugai" value="tsubugai">Tsubugai'
+      )
+    end
+  end
+
+  describe 'with numeric value' do
+    let(:object) { double('object', role_id: role_id_value) }
+    let(:role_id_value) { 2 }
+    let(:field) do
+      Superform::Rails::Field.new(:role_id, parent: nil, object: object)
+    end
+    let(:options) { [[1, 'Admin'], [2, 'Editor'], [3, 'Viewer']] }
+
+    subject { render(component) }
+
+    it 'checks the matching radio button with numeric comparison' do
+      expect(subject).to match(
+        /<input[^>]*id="role_id_2"[^>]*checked[^>]*>/
+      )
+    end
+  end
+
+  describe 'using field helper method' do
+    let(:form_field) do
+      Superform::Rails::Field.new(:sushi, parent: nil, object: object)
+    end
+
+    context 'with positional arguments' do
+      subject do
+        render(
+          form_field.radio(
+            ['shirako', 'Shirako'],
+            ['ankimo', 'Ankimo'],
+            ['tsubugai', 'Tsubugai']
+          )
+        )
+      end
+
+      it 'renders radio buttons from positional args' do
+        expect(subject).to include('value="shirako"')
+        expect(subject).to include('value="ankimo"')
+        expect(subject).to include('value="tsubugai"')
+      end
+    end
+
+    context 'with options keyword argument' do
+      subject do
+        render(
+          form_field.radio(
+            options: [
+              ['shirako', 'Shirako'],
+              ['ankimo', 'Ankimo'],
+              ['tsubugai', 'Tsubugai']
+            ]
+          )
+        )
+      end
+
+      it 'renders radio buttons from options kwarg' do
+        expect(subject).to include('value="shirako"')
+        expect(subject).to include('value="ankimo"')
+        expect(subject).to include('value="tsubugai"')
+      end
+    end
+
+    context 'with single value (legacy API)' do
+      subject do
+        render(form_field.radio('shirako', id: 'custom_id'))
+      end
+
+      it 'renders a single radio input' do
+        expect(subject).to include('type="radio"')
+        expect(subject).to include('value="shirako"')
+        expect(subject).to include('id="custom_id"')
+      end
+
+      it 'renders only one radio button' do
+        expect(subject.scan(/<input/).count).to eq(1)
+      end
+    end
+  end
+
+  describe 'with custom attributes' do
+    let(:attributes) { { class: 'custom-radio', data: { controller: 'radio' } } }
+
+    subject { render(component) }
+
+    it 'applies custom attributes to all radio buttons' do
+      expect(subject).to include('class="custom-radio"')
+      expect(subject).to include('data-controller="radio"')
+      expect(subject.scan(/class="custom-radio"/).count).to eq(3)
+    end
+  end
+
+  describe 'with block for custom rendering' do
+    subject do
+      render(component) do |radio|
+        radio.button('shirako') { 'Shirako' }
+        radio.button('ankimo') { 'Ankimo' }
+      end
+    end
+
+    it 'renders custom radio buttons via block' do
+      expect(subject).to include('value="shirako"')
+      expect(subject).to include('value="ankimo"')
+    end
+
+    it 'does not render options from constructor' do
+      expect(subject).not_to include('value="tsubugai"')
+    end
+  end
+
+  describe '#button method' do
+    let(:component) do
+      described_class.new(field, attributes: {}, options: [])
+    end
+
+    context 'with simple value and label' do
+      subject do
+        render(component) do |radio|
+          radio.button('omakase') { 'Chef\'s Choice' }
+        end
+      end
+
+      it 'renders radio button with value and label' do
+        expect(subject).to include('value="omakase"')
+        expect(subject).to include('>Chef&#39;s Choice')
+      end
+
+      it 'generates ID from field name and value' do
+        expect(subject).to include('id="sushi_omakase"')
+      end
+    end
+  end
+
+  describe 'inside a collection (with parent field)' do
+    let(:orders_field) do
+      orders_object = double('orders', orders: [{}, {}])
+      Superform::Rails::Field.new(
+        :orders,
+        parent: nil,
+        object: orders_object,
+        value: [{}, {}]
+      )
+    end
+    let(:order_collection) { orders_field.collection }
+    let(:order_field) { order_collection.field }
+    let(:sushi_field) do
+      sushi_object = double('order', sushi: nil)
+      Superform::Rails::Field.new(:sushi, parent: order_field, object: sushi_object)
+    end
+    let(:component) do
+      described_class.new(
+        sushi_field,
+        attributes: attributes,
+        options: options
+      )
+    end
+
+    subject { render(component) }
+
+    it 'uses collection notation for field name' do
+      # When parent is a Field (from collection), it should use orders[][]
+      # First [] is the collection index, second [] is the field
+      expect(subject).to include('name="orders[][]"')
+    end
+
+    it 'does not include the sushi key in the name' do
+      # The sushi key is excluded when parent is a Field
+      expect(subject).not_to include('name="orders[][][sushi]"')
+    end
+
+    it 'generates unique IDs including collection index' do
+      expect(subject).to include('id="orders_1_sushi_shirako"')
+      expect(subject).to include('id="orders_1_sushi_ankimo"')
+      expect(subject).to include('id="orders_1_sushi_tsubugai"')
+    end
+
+    it 'renders all radio buttons correctly' do
+      expect(subject.scan(/<input[^>]*type="radio"/).count).to eq(3)
+      expect(subject).to include('value="shirako"')
+      expect(subject).to include('value="ankimo"')
+      expect(subject).to include('value="tsubugai"')
+    end
+  end
+
+  describe 'with ActiveRecord::Relation' do
+    before do
+      User.create!(first_name: 'Alice', email: 'alice@example.com')
+      User.create!(first_name: 'Bob', email: 'bob@example.com')
+    end
+
+    after do
+      User.delete_all
+    end
+
+    let(:object) { double('object', author_id: author_id_value) }
+    let(:author_id_value) { nil }
+    let(:field) do
+      Superform::Rails::Field.new(:author_id, parent: nil, object: object)
+    end
+    let(:users_relation) { User.select(:id, :first_name) }
+    let(:component) do
+      described_class.new(field, attributes: attributes, options: [users_relation])
+    end
+
+    subject { render(component) }
+
+    it 'renders radio buttons from ActiveRecord relation' do
+      # OptionMapper extracts id as value and joins other attributes as label
+      expect(subject).to match(/<input[^>]*value="\d+"[^>]*>Alice/)
+      expect(subject).to match(/<input[^>]*value="\d+"[^>]*>Bob/)
+    end
+
+    it 'generates IDs from field name and record ID' do
+      alice = User.find_by(first_name: 'Alice')
+      expect(subject).to include("id=\"author_id_#{alice.id}\"")
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/spec/superform/rails/components/radio_spec.rb
+++ b/spec/superform/rails/components/radio_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Superform::Rails::Components::Radio, type: :view do
     ]
   end
   let(:component) do
-    described_class.new(field, attributes: attributes, options: options)
+    described_class.new(field, *options, attributes: attributes)
   end
   let(:attributes) { {} }
 
@@ -187,9 +187,39 @@ RSpec.describe Superform::Rails::Components::Radio, type: :view do
     end
   end
 
+  describe 'with block but no constructor options' do
+    let(:object) { double('object', plan: nil) }
+    let(:field) do
+      Superform::Rails::Field.new(:plan, parent: nil, object: object)
+    end
+    let(:component) do
+      described_class.new(field, attributes: {})
+    end
+
+    subject do
+      render(component) do |radio|
+        radio.option('free') { 'Free Plan' }
+        radio.option('pro') { 'Pro Plan' }
+      end
+    end
+
+    it 'renders radio buttons from block without constructor options' do
+      expect(subject).to include('value="free"')
+      expect(subject).to include('value="pro"')
+    end
+
+    it 'wraps each radio button in a label' do
+      expect(subject.scan(/<label>/).count).to eq(2)
+    end
+
+    it 'uses the same name for all radio buttons' do
+      expect(subject.scan(/name="plan"/).count).to eq(2)
+    end
+  end
+
   describe '#option method' do
     let(:component) do
-      described_class.new(field, attributes: {}, options: [])
+      described_class.new(field, attributes: {})
     end
 
     context 'with simple value and label' do
@@ -229,8 +259,8 @@ RSpec.describe Superform::Rails::Components::Radio, type: :view do
     let(:component) do
       described_class.new(
         sushi_field,
-        attributes: attributes,
-        options: options
+        *options,
+        attributes: attributes
       )
     end
 
@@ -278,7 +308,7 @@ RSpec.describe Superform::Rails::Components::Radio, type: :view do
     end
     let(:users_relation) { User.select(:id, :first_name) }
     let(:component) do
-      described_class.new(field, attributes: attributes, options: [users_relation])
+      described_class.new(field, users_relation, attributes: attributes)
     end
 
     subject { render(component) }

--- a/spec/superform/rails/components/radio_spec.rb
+++ b/spec/superform/rails/components/radio_spec.rb
@@ -172,8 +172,8 @@ RSpec.describe Superform::Rails::Components::Radio, type: :view do
   describe 'with block for custom rendering' do
     subject do
       render(component) do |radio|
-        radio.button('shirako') { 'Shirako' }
-        radio.button('ankimo') { 'Ankimo' }
+        radio.option('shirako') { 'Shirako' }
+        radio.option('ankimo') { 'Ankimo' }
       end
     end
 
@@ -187,7 +187,7 @@ RSpec.describe Superform::Rails::Components::Radio, type: :view do
     end
   end
 
-  describe '#button method' do
+  describe '#option method' do
     let(:component) do
       described_class.new(field, attributes: {}, options: [])
     end
@@ -195,7 +195,7 @@ RSpec.describe Superform::Rails::Components::Radio, type: :view do
     context 'with simple value and label' do
       subject do
         render(component) do |radio|
-          radio.button('omakase') { 'Chef\'s Choice' }
+          radio.option('omakase') { 'Chef\'s Choice' }
         end
       end
 

--- a/spec/superform/rails/components/radio_spec.rb
+++ b/spec/superform/rails/components/radio_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Superform::Rails::Components::Radio, type: :view do
   end
   let(:attributes) { {} }
 
-  describe 'basic radio collection' do
+  describe 'radio group with options' do
     subject { render(component) }
 
     it 'renders multiple radio inputs' do

--- a/spec/superform/rails/field_convenience_methods_spec.rb
+++ b/spec/superform/rails/field_convenience_methods_spec.rb
@@ -25,7 +25,10 @@ RSpec.describe Superform::Rails::Form::Field do
     it { expect(field.color.type).to eq("color") }
     it { expect(field.search.type).to eq("search") }
     it { expect(field.file.type).to eq("file") }
-    it { expect(field.radio("male").type).to eq("radio") }
+    it do
+      component = field.radio(['male', 'Male'], ['female', 'Female'])
+      expect(component).to be_a(Superform::Rails::Components::Radio)
+    end
   end
 
   describe "Rails compatibility aliases" do
@@ -55,9 +58,10 @@ RSpec.describe Superform::Rails::Form::Field do
       expect(component.type).to eq("search")
     end
 
-    it "handles radio button value parameter correctly" do
-      component = field.radio("female", class: "radio-input", data: { value: "f" })
-      expect(component.type).to eq("radio")
+    it "handles radio button collection with attributes correctly" do
+      component = field.radio(['male', 'Male'], ['female', 'Female'],
+                              class: "radio-input", data: { value: "f" })
+      expect(component).to be_a(Superform::Rails::Components::Radio)
     end
   end
 end


### PR DESCRIPTION
This PR adds **array mode** to Checkbox and adds Radio components, enabling multi-select checkboxes and radio button groups.

### What's New
-  **Multi-select checkboxes** - Array of checkbox options for selecting multiple values for the same field
-  **Radio button groups** - Single-select from multiple radio options for a field
-  **Positional argument API** - Pass options directly as arguments
-  **Block rendering** - Custom markup with `option` method
-  **ActiveRecord relation support** - Pass AR relations directly as the options (positional arg)
-  **Consistent with Select** - Uses `option` method for rendering custom content, as `Select` component currently does

### Backward Compatibility
All existing boolean checkbox functionality remains unchanged.

## New API

### Checkbox Array Mode

#### Multi-select with positional arguments
```ruby
field(:role_ids).checkbox(
  [1, "Admin"],
  [2, "Editor"],
  [3, "Viewer"]
)
# Renders:
# <label><input type="checkbox" name="role_ids[]" value="1">Admin</label>
# <label><input type="checkbox" name="role_ids[]" value="2">Editor</label>
# <label><input type="checkbox" name="role_ids[]" value="3">Viewer</label>
```

#### Custom rendering with block
```ruby
field(:feature_ids).checkbox do |c|
  div(class: "feature-option") do
    c.option(1) { "Dark Mode" }
  end
  div(class: "feature-option") do
    c.option(2) { "Notifications" }
  end
end
```

#### With ActiveRecord relations
```ruby
field(:tag_ids).checkbox(Tag.select(:id, :name))
# Automatically uses id as value, name as label
```

#### Boolean mode (unchanged)
```ruby
field(:agreement).checkbox
# Still works exactly as before:
# <input type="hidden" name="agreement" value="0">
# <input type="checkbox" name="agreement" value="1">
```

### Radio Array Mode

#### Single-select with positional arguments
```ruby
field(:plan).radio(
  ["free", "Free Plan"],
  ["pro", "Pro Plan"],
  ["enterprise", "Enterprise"]
)
# Renders:
# <label><input type="radio" name="plan" value="free">Free Plan</label>
# <label><input type="radio" name="plan" value="pro">Pro Plan</label>
# <label><input type="radio" name="plan" value="enterprise">Enterprise</label>
```

#### Custom rendering with block
```ruby
field(:gender).radio do |r|
  div(class: "radio-option") do
    r.option("m") { "Male" }
  end
  div(class: "radio-option") do
    r.option("f") { "Female" }
  end
  div(class: "radio-option") do
    r.option("o") { "Other" }
  end
end
```

#### With ActiveRecord relations
```ruby
field(:category_id).radio(Category.select(:id, :name))
```

## Usage Examples

### Basic Form Example

```ruby
class SignupForm < Components::Form
  def view_template
    # Multi-select checkboxes
    div do
      field(:role_ids).label(for: false) { "Select your roles" }
      field(:role_ids).checkbox(
        [1, "Admin"],
        [2, "Editor"],
        [3, "Viewer"]
      )
    end

    # Radio button group
    div do
      field(:plan).label(for: false) { "Choose your plan" }
      field(:plan).radio(
        ["free", "Free Plan"],
        ["pro", "Pro Plan"],
        ["enterprise", "Enterprise"]
      )
    end

    # Boolean checkbox (unchanged)
    div do
      field(:terms).label { "I agree to the terms" }
      field(:terms).checkbox
    end

    submit
  end
end
```

### Advanced: Custom Markup

```ruby
# Checkbox with custom styling
field(:features).checkbox do |c|
  div(class: "features-grid") do
    div(class: "feature-card") do
      c.option("dark_mode") do
        strong { "Dark Mode" }
        p { "Easy on the eyes" }
      end
    end
    div(class: "feature-card") do
      c.option("notifications") do
        strong { "Notifications" }
        p { "Stay updated" }
      end
    end
  end
end

# Radio with custom layout
field(:plan).radio do |r|
  div(class: "pricing-cards") do
    div(class: "card") do
      r.option("free") do
        h3 { "Free" }
        p { "$0/month" }
      end
    end
    div(class: "card") do
      r.option("pro") do
        h3 { "Pro" }
        p { "$10/month" }
      end
    end
  end
end
```

## Option Format

Options accept multiple formats for flexibility:

```ruby
# Array pairs [value, label]
field(:size).radio(
  ["s", "Small"],
  ["m", "Medium"],
  ["l", "Large"]
)

# Single values (used as both value and label)
field(:tags).checkbox(
  "Ruby",
  "Rails",
  "Hotwire"
)

# Mixed formats
field(:contact).radio(
  [true, "Yes, contact me"],
  [false, "No thanks"],
  "Maybe later"
)

# ActiveRecord relation
field(:category_ids).checkbox(Category.all)
```

## Component API

### Checkbox Component

```ruby
# Constructor accepts options as positional args
Checkbox.new(field, *option_list, attributes: {})

# Public methods
def options(*option_list)  # Renders all options
def option(value, &block)  # Renders single option with label
```

### Radio Component

```ruby
# Constructor accepts options as positional args
Radio.new(field, *option_list, attributes: {})

# Public methods
def options(*option_list)  # Renders all options
def option(value, &block)  # Renders single option with label
```

## Implementation Details

### How Array Mode is Determined

**Checkbox:**
- Array mode if options provided OR block given
- Boolean mode otherwise (backward compatible)

```ruby
def view_template(&block)
  if array_mode? || block_given?
    # Array mode: multiple checkboxes
  else
    # Boolean mode: single true/false checkbox
  end
end
```

**Radio:**
- Always renders provided options (no boolean mode)
- Supports block rendering for custom markup

### Checked State Logic

**Checkbox (multi-select):**
```ruby
def checked_in_collection?(value)
  field_value = field.value
  return false if field_value.nil?

  field_value = [field_value] unless field_value.is_a?(Array)
  field_value.map(&:to_s).include?(value.to_s)
end
```

**Radio (single-select):**
```ruby
def checked?(value)
  field.value.to_s == value.to_s
end
```

### HTML Output

**Checkbox array:**
```html
<!-- Uses array notation for multi-select -->
<label>
  <input type="checkbox" name="role_ids[]" value="1">
  Admin
</label>
```

**Radio group:**
```html
<!-- Shares same name for mutually exclusive selection -->
<label>
  <input type="radio" name="plan" value="free">
  Free Plan
</label>
```

## Why This Design?

### Positional Arguments
Options are inherently a list of choices. Passing them as positional arguments (`*args`) is more natural than a keyword argument:

```ruby
# Intuitive - reads like a list
field(:plan).radio(["free", "Free"], ["pro", "Pro"])

# vs. more verbose
field(:plan).radio(options: [["free", "Free"], ["pro", "Pro"]])
```

### Block-Only Support
Enables clean custom rendering without redundant constructor arguments:

```ruby
# Clean - define options inline with custom markup
field(:gender).radio do |r|
  div { r.option("m") { "Male" } }
  div { r.option("f") { "Female" } }
end

# vs. having to repeat options
field(:gender).radio(["m", "Male"], ["f", "Female"]) do |r|
  div { r.option("m") { "Male" } }  # Redundant!
end
```

### Consistent Naming
Using `option` aligns with Select component terminology and HTML `<option>` elements:

```ruby
# Consistent across components
field(:category).select { |s| s.option(...) }
field(:tags).checkbox { |c| c.option(...) }
field(:plan).radio { |r| r.option(...) }
```
