### PR TITLE
Bump required Ruby version to 2.7.0

### DIFF
--- a/superform.gemspec
+++ b/superform.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "A better way to customize and build forms for your Rails application"
   spec.homepage = "https://github.com/rubymonolith/superform"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 


### PR DESCRIPTION
This Ruby [version change](https://github.com/rubymonolith/superform/pull/33#discussion_r2056084479) was first brought up by @mvkampen. He noted that argument forwarding is used throughout superform, but it was introduced in ruby 2.7. It seems the state of the code is a bit ahead of the required version of the gem. 

Ruby 2.6 reached end-of-life in March 2022.